### PR TITLE
Fix broken URLs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -365,7 +365,7 @@ The `name` and `reference` parameter identify the image and are required.
 The reference may include a tag or digest.
 
 The client should include an Accept header indicating which manifest content types it supports.
-For more details on the manifest formats and their content types, see [manifest-v2-1.md](manifest-v2-1.md) and [manifest-v2-2.md](manifest-v2-2.md).
+For more details on the manifest formats and their content types, see [manifest-v2-1.md](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md) and [manifest-v2-2.md](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md).
 In a successful response, the Content-Type header will indicate which manifest type is being returned.
 
 A `404 Not Found` response will be returned if the image is unknown to the registry.

--- a/spec.md
+++ b/spec.md
@@ -935,7 +935,7 @@ If the image had already been deleted or did not exist, a `404 Not Found` respon
 
     Accept: application/vnd.docker.distribution.manifest.v2+json
 
-> for more details, see: [compatibility.md](../compatibility.md#content-addressable-storage-cas)
+> for more details, see: [compatibility.md](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#backward-compatibility)
 
 ## Detail
 


### PR DESCRIPTION
Ideally, we could vendor/remove any references to outside of this repository, to avoid any loss of information.

I did my best to find a comparable link for the compatibility one.