### PR TITLE
Import rest of tests from kinvolk/ocicert

### DIFF
--- a/test/dist/dist_test.go
+++ b/test/dist/dist_test.go
@@ -180,6 +180,21 @@ func testPullManifest(t *testing.T) {
 	if _, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK}); err != nil {
 		t.Fatalf("got an unexpected reply: %v", err)
 	}
+
+	reqPath = filepath.Join(remoteName, "tags/list")
+
+	regAuthCtx.Scope.RemoteName = remoteName
+	regAuthCtx.Scope.Actions = "pull"
+
+	if err := regAuthCtx.PrepareAuth(indexServer); err != nil {
+		t.Fatalf("failed to prepare auth to %s for %s: %v", indexServer, reqPath, err)
+	}
+
+	inputURL = "https://" + indexServer + "/v2/" + reqPath
+
+	if _, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK}); err != nil {
+		t.Fatalf("got an unexpected reply: %v", err)
+	}
 }
 
 func testPullLayer(t *testing.T) {
@@ -301,7 +316,7 @@ func TestListTags(t *testing.T) {
 	indexServer := auth.GetIndexServer(regURL)
 
 	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
-	reqPath := filepath.Join(remoteName, "tags/list")
+	reqPath := filepath.Join(remoteName, "tags/")
 
 	regAuthCtx.Scope.RemoteName = remoteName
 	regAuthCtx.Scope.Actions = "pull"

--- a/test/dist/dist_test.go
+++ b/test/dist/dist_test.go
@@ -268,3 +268,51 @@ func TestPushPullLayer(t *testing.T) {
 	testDeleteLayer(t)
 	testDeleteManifest(t)
 }
+
+func TestListRepos(t *testing.T) {
+	reqPath := "_catalog"
+
+	regAuthCtx := auth.NewRegAuthContext()
+	regURL := regAuthCtx.RegURL
+
+	regAuthCtx.Scope.RemoteName = reqPath
+	regAuthCtx.Scope.Actions = "pull"
+
+	indexServer := auth.GetIndexServer(regURL)
+
+	// NOTE: it will fail when testing against docker.io, as '/v2/_catalog' endpoint
+	// will not be supported.
+	if err := regAuthCtx.PrepareAuth(indexServer); err != nil {
+		t.Fatalf("failed to prepare auth to %s for %s: %v", indexServer, reqPath, err)
+	}
+
+	inputURL := "https://" + indexServer + "/v2/" + reqPath
+
+	_, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK})
+	if err != nil {
+		t.Fatalf("got an unexpected reply: %v", err)
+	}
+}
+
+func TestListTags(t *testing.T) {
+	regAuthCtx := auth.NewRegAuthContext()
+	regURL := regAuthCtx.RegURL
+
+	indexServer := auth.GetIndexServer(regURL)
+
+	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
+	reqPath := filepath.Join(remoteName, "tags/list")
+
+	regAuthCtx.Scope.RemoteName = remoteName
+	regAuthCtx.Scope.Actions = "pull"
+
+	if err := regAuthCtx.PrepareAuth(indexServer); err != nil {
+		t.Fatalf("failed to prepare auth to %s for %s: %v", indexServer, reqPath, err)
+	}
+
+	inputURL := "https://" + indexServer + "/v2/" + reqPath
+
+	if _, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK}); err != nil {
+		t.Fatalf("got an unexpected reply: %v", err)
+	}
+}

--- a/test/pkg/distp/distp.go
+++ b/test/pkg/distp/distp.go
@@ -19,4 +19,5 @@ const (
 	DistAPIVersionValue string = "registry/2.0"
 
 	UploadUuidKey string = "Docker-Upload-Uuid"
+	ContentDigest string = "Docker-Content-Digest"
 )

--- a/test/pkg/image/util.go
+++ b/test/pkg/image/util.go
@@ -13,3 +13,23 @@
 // limitations under the License.
 
 package image
+
+import (
+	"crypto/sha256"
+	"math/rand"
+	"strconv"
+)
+
+func GenRandomBlob(blobLen int) string {
+	blob := ""
+	for i := 0; i < blobLen; i++ {
+		blob += strconv.Itoa(rand.Intn(9))
+	}
+	return blob
+}
+
+func GetHash(inputStr string) string {
+	h := sha256.New()
+	h.Write([]byte(inputStr))
+	return string(h.Sum(nil))
+}


### PR DESCRIPTION
This PR basically combines 2 original PRs into one: https://github.com/kinvolk/ocicert/pull/2 and https://github.com/kinvolk/ocicert/pull/5

The PR adds more tests such as UploadLayer, PushManifest, PullManifest, PullLayer, DeleteLayer, DeleteManifest.
Review comments were partly addressed. There are still open issues like [this](https://github.com/kinvolk/ocicert/pull/5#discussion_r242939621).

If there's any comment, please comment to this PR. I can update it.