### PR TITLE
spec: fix binary JSON content-type

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -982,7 +982,7 @@ The registry does not implement the V2 API.
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1016,7 +1016,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1075,7 +1075,7 @@ The following parameters should be specified on the request:
 ```
 200 OK
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "name": <name>,
@@ -1100,7 +1100,7 @@ The following headers will be returned with the response:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1134,7 +1134,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1167,7 +1167,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1200,7 +1200,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1250,7 +1250,7 @@ The following parameters should be specified on the request:
 200 OK
 Content-Length: <length>
 Link: <<url>?n=<last n value>&last=<last entry from response>>; rel="next"
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "name": <name>,
@@ -1276,7 +1276,7 @@ The following headers will be returned with the response:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1310,7 +1310,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1343,7 +1343,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1376,7 +1376,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1463,7 +1463,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1492,7 +1492,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1526,7 +1526,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1559,7 +1559,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1592,7 +1592,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1677,7 +1677,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1710,7 +1710,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1744,7 +1744,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1777,7 +1777,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1810,7 +1810,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1843,7 +1843,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "errors:" [{
@@ -1911,7 +1911,7 @@ The following parameters should be specified on the request:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1942,7 +1942,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1976,7 +1976,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2009,7 +2009,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2042,7 +2042,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2074,7 +2074,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2181,7 +2181,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2208,7 +2208,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2237,7 +2237,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2273,7 +2273,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2306,7 +2306,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2339,7 +2339,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2415,7 +2415,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2442,7 +2442,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2478,7 +2478,7 @@ This can happen when the range is not formatted correctly or if the range is out
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2512,7 +2512,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2545,7 +2545,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2578,7 +2578,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2658,7 +2658,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2685,7 +2685,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 405 Method Not Allowed
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2713,7 +2713,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2747,7 +2747,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2780,7 +2780,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2813,7 +2813,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2930,7 +2930,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2964,7 +2964,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2997,7 +2997,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3030,7 +3030,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3120,7 +3120,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3154,7 +3154,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3187,7 +3187,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3220,7 +3220,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3325,7 +3325,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3360,7 +3360,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3393,7 +3393,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3426,7 +3426,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3506,7 +3506,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3534,7 +3534,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3563,7 +3563,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3597,7 +3597,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3630,7 +3630,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3663,7 +3663,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3743,7 +3743,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3773,7 +3773,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3802,7 +3802,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3836,7 +3836,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3869,7 +3869,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3902,7 +3902,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3983,7 +3983,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4011,7 +4011,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4048,7 +4048,7 @@ The `Content-Range` specification cannot be accepted, either because it does not
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4082,7 +4082,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4115,7 +4115,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4148,7 +4148,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4230,7 +4230,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4259,7 +4259,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4288,7 +4288,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4322,7 +4322,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4355,7 +4355,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4388,7 +4388,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4459,7 +4459,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4487,7 +4487,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4516,7 +4516,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4550,7 +4550,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4583,7 +4583,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4616,7 +4616,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4668,7 +4668,7 @@ The implementation may impose a maximum limit and return a partial set with pagi
 ```
 200 OK
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"repositories": [
@@ -4707,7 +4707,7 @@ The following parameters should be specified on the request:
 200 OK
 Content-Length: <length>
 Link: <<url>?n=<last n value>&last=<last entry from response>>; rel="next"
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"repositories": [


### PR DESCRIPTION
This fixes endpoints examples to return the proper `application/json`
content-type for JSON content.

As per IETF specification and IANA registry below, the `application/json`
type is a binary media, so the content-type label does not need any
text-charset selector. Additionally, the media type definition
explicitly states that it has no required nor optional parameters,
which makes the current registry headers non-compliant.

Ref: https://www.iana.org/assignments/media-types/application/json

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>