### PR TITLE
Add Go structs

### DIFF
--- a/.tool/genheader.go
+++ b/.tool/genheader.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"text/template"
 
-	distspec "github.com/opencontainers/distribution-spec"
+	specs "github.com/opencontainers/distribution-spec/specs-go"
 )
 
 var headerTemplate = template.Must(template.New("gen").Parse(`<title>distribution-spec {{.Version}}</title>
@@ -35,10 +35,10 @@ type Obj struct {
 
 func main() {
 	obj := Obj{
-		Version: distspec.Version,
-		Branch:  distspec.Version,
+		Version: specs.Version,
+		Branch:  specs.Version,
 	}
-	if strings.HasSuffix(distspec.Version, "-dev") {
+	if strings.HasSuffix(specs.Version, "-dev") {
 		cmd := exec.Command("git", "log", "-1", `--pretty=%H`, "HEAD")
 		var out bytes.Buffer
 		cmd.Stdout = &out

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ $(OUTPUT_DIRNAME)/$(DOC_FILENAME).html: header.html $(DOC_FILES) $(FIGURE_FILES)
 	ls -sh $(realpath $@)
 endif
 
-header.html: .tool/genheader.go version.go
+header.html: .tool/genheader.go specs-go/version.go
 	go run .tool/genheader.go > $@
 
 install.tools: .install.gitvalidation

--- a/specs-go/v1/error.go
+++ b/specs-go/v1/error.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// ErrorResponse is returned by a registry on an invalid request.
+type ErrorResponse struct {
+	Errors []ErrorInfo `json:"errors"`
+}
+
+// Error implements the Error interface.
+func (er *ErrorResponse) Error() string {
+	return "distribution: registry returned error"
+}
+
+// Detail returns an ErrorInfo
+func (er *ErrorResponse) Detail() []ErrorInfo {
+	return er.Errors
+}
+
+// ErrorInfo describes a server error returned from a registry.
+type ErrorInfo struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Detail  string `json:"detail"`
+}

--- a/specs-go/v1/error.go
+++ b/specs-go/v1/error.go
@@ -19,9 +19,12 @@ type ErrorResponse struct {
 	Errors []ErrorInfo `json:"errors"`
 }
 
+// ErrRegistry is the string returned by and ErrorResponse error.
+var ErrRegistry = "distribution: registry returned error"
+
 // Error implements the Error interface.
 func (er *ErrorResponse) Error() string {
-	return "distribution: registry returned error"
+	return ErrRegistry
 }
 
 // Detail returns an ErrorInfo

--- a/specs-go/v1/repository.go
+++ b/specs-go/v1/repository.go
@@ -1,0 +1,20 @@
+// Copyright 2019 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// RepositoryList returns a catalog of repositories maintained on the registry.
+type RepositoryList struct {
+	Repositories []string `json:"repositories"`
+}

--- a/specs-go/v1/tags.go
+++ b/specs-go/v1/tags.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// TagList is a list of tags for a given repository.
+type TagList struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Linux Foundation
+// Copyright 2019 The Linux Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package distspec
+package specs
 
 import "fmt"
 


### PR DESCRIPTION
This PR adds Go structs for schemas defined by the distribution spec. There's not many but it will be easier to reason about adding more custom schemas in the future.