### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Development happens on GitHub.
 Responsible disclosure for security issues is discussed [here](CONTRIBUTING.md#security-issues).
 [Issues][issues] are used for non-security bugs and actionable items; longer discussions can happen on the [mailing list](#mailing-list).
 
-## Security Issues
-
 ### Mailing list
 
 You can subscribe and browse the mailing list on [Google Groups][mailing-list].

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# OCI Distribution Specification
 <div>
 <a href="https://travis-ci.org/opencontainers/distribution-spec">
 <img src="https://travis-ci.org/opencontainers/distribution-spec.svg?branch=master"></img>
 </a>
 </div>
+
+# OCI Distribution Specification
 
 The OCI Distribution Specification defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # OCI Distribution Specification
 
-The OCI Distribution Specification defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
+The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
 
 **The specification can be found [here][spec].**
 
@@ -25,7 +25,7 @@ Development happens on GitHub.
 Responsible disclosure for security issues is discussed [here](CONTRIBUTING.md#security-issues).
 [Issues][issues] are used for non-security bugs and actionable items; longer discussions can happen on the [mailing list](#mailing-list).
 
-### Mailing list
+## Mailing list
 
 You can subscribe and browse the mailing list on [Google Groups][mailing-list].
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 # OCI Distribution Specification
 
-The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
-
-The specification can be found [here][spec].
+The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec]. The specification can be found [here][spec].
 
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Distribution project defines a collection of HTTP endpoints used to distribu
 The specification can be found [here][spec].
 
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
+The Go types and validation should be compatible with the current Go release; earlier Go releases are not supported.
 
 For additional documentation about how this group operates, refer to the [org repo][org].
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
 
-**The specification can be found [here][spec].**
+The specification can be found [here][spec].
 
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 
 # OCI Distribution Specification
 
-The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec]. The specification can be found [here][spec].
-
+The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
+The specification can be found [here][spec].
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
-
 Additional documentation about how this group operates, refer to the [org repo][org].
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,40 +1,44 @@
-## Open Container Initiative Distribution Specification
+# OCI Distribution Specification
+<div>
+<a href="https://travis-ci.org/opencontainers/distribution-spec">
+<img src="https://travis-ci.org/opencontainers/distribution-spec.svg?branch=master"></img>
+</a>
+</div>
 
-The [Open Container Initiative](https://www.opencontainers.org/) develops specifications for standards on Operating System process and application containers.
+The OCI Distribution Specification defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
 
-The specification can be found [here](https://github.com/opencontainers/distribution-spec/blob/master/spec.md).
+**The specification can be found [here][spec].**
 
-### Table of Contents
+This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
+
+Additional documentation about how this group operates:
 
 - [Code of Conduct][code-of-conduct]
-- [Releases](RELEASES.md)
-- [charter][charter]
+- [Releases][releases]
+- [Charter][charter]
 
-### Use Cases
-
-Following sections give context for aspects of this specification:
-
-### Registry Developers
-
-### Registry Administrators
-
-### Client Side Image Tools
-
-### Container Image Pipeline
 
 ## Contributing
-
-See [our contribution documentation](CONTRIBUTING.md).
 
 Development happens on GitHub.
 Responsible disclosure for security issues is discussed [here](CONTRIBUTING.md#security-issues).
 [Issues][issues] are used for non-security bugs and actionable items; longer discussions can happen on the [mailing list](#mailing-list).
 
+## Security Issues
+
 ### Mailing list
 
 You can subscribe and browse the mailing list on [Google Groups][mailing-list].
 
+[spec]: spec.md
+[specs-go]: specs-go
+[schemas]: schemas
+[releases]: RELEASES.md
+[contributing]: CONTRIBUTING.md
+
+[oci]: https://www.opencontainers.org
 [charter]: https://www.opencontainers.org/about/governance
 [code-of-conduct]: https://github.com/opencontainers/tob/blob/master/code-of-conduct.md
 [issues]: https://github.com/opencontainers/distribution-spec/issues
 [mailing-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+[image-spec]: https://github.com/opencontainers/image-spec

--- a/README.md
+++ b/README.md
@@ -12,22 +12,13 @@ The specification can be found [here][spec].
 
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
 
-Additional documentation about how this group operates:
-
-- [Code of Conduct][code-of-conduct]
-- [Releases][releases]
-- [Charter][charter]
-
+Additional documentation about how this group operates, refer to the [org repo][org].
 
 ## Contributing
 
 Development happens on GitHub.
 Responsible disclosure for security issues is discussed [here](CONTRIBUTING.md#security-issues).
-[Issues][issues] are used for non-security bugs and actionable items; longer discussions can happen on the [mailing list](#mailing-list).
-
-## Mailing list
-
-You can subscribe and browse the mailing list on [Google Groups][mailing-list].
+[Issues][issues] are used for non-security bugs and actionable items; longer discussions can happen on the [mailing list][mailing-list].
 
 [spec]: spec.md
 [specs-go]: specs-go
@@ -35,9 +26,8 @@ You can subscribe and browse the mailing list on [Google Groups][mailing-list].
 [releases]: RELEASES.md
 [contributing]: CONTRIBUTING.md
 
+[org]: https://github.com/opencontainers/org.com
 [oci]: https://www.opencontainers.org
-[charter]: https://www.opencontainers.org/about/governance
-[code-of-conduct]: https://github.com/opencontainers/tob/blob/master/code-of-conduct.md
 [issues]: https://github.com/opencontainers/distribution-spec/issues
 [mailing-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
 [image-spec]: https://github.com/opencontainers/image-spec

--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@
 # OCI Distribution Specification
 
 The Distribution project defines a collection of HTTP endpoints used to distribute [OCI Images][image-spec].
+
 The specification can be found [here][spec].
+
 This repository also provides [Go types][specs-go] and [JSON Schemas][schemas].
-Additional documentation about how this group operates, refer to the [org repo][org].
+
+For additional documentation about how this group operates, refer to the [org repo][org].
 
 ## Contributing
 


### PR DESCRIPTION
Our README sucks. I was able to clean it up a bit thanks to the new `org` repo.

Let's use this PR for discussion on what everyone thinks should be included on the landing page.