### PR TITLE
Correct grammar for digest algorithm portion

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -234,7 +234,7 @@ We define a _digest_ string to match the following grammar:
 
 ```EBNF
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 


### PR DESCRIPTION
The current grammar specifies that the characters `[A-Fa-f0-9_+.-]` are valid in the `algorithm` portion of a digest. This contradicts the specification stating that:
> compliant implementations SHOULD use sha256

`sha256` does not match the above rule.

This pull request fixes this issue by additionally allowing characters `g-zG-Z` in the `algorithm` portion.