### PR TITLE
Update blob patch status code to correct code

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3740,7 +3740,7 @@ The following parameters SHOULD be specified on the request:
 ###### On Success: Data Accepted
 
 ```HTTP
-204 No Content
+202 Accepted
 Location: /v2/<name>/blobs/uploads/<uuid>
 Range: 0-<offset>
 Content-Length: 0
@@ -3978,7 +3978,7 @@ The following parameters SHOULD be specified on the request:
 ###### On Success: Chunk Accepted
 
 ```HTTP
-204 No Content
+202 Accepted
 Location: /v2/<name>/blobs/uploads/<uuid>
 Range: 0-<offset>
 Content-Length: 0


### PR DESCRIPTION
The PATCH blob upload endpoint returns a 202 Accepted when a chunk
is accepted rather than a 204. The 204 is returned by the PUT
endpoint after completion of an upload is successful. The status
code in the detail section must match the protocol as described
in the description for upload patching. It is stated at the beginning
of the detail section that when the detail does not match, the
description above it is correct.