### PR TITLE
spec: `Location` can be absolute or relative

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -387,6 +387,8 @@ Uploads are started with a POST request which returns a url that can be used to 
 
 The `Location` header will be used to communicate the upload location after each request.
 While it won't change in the this specification, clients SHOULD use the most recent value returned by the API.
+`Location` header value returned MUST either be absolute or relative as described in
+[RFC 7231](https://tools.ietf.org/html/rfc7231#section-7.1.2).
 
 ##### Starting An Upload
 


### PR DESCRIPTION
From the spec it is not clear how the `Location` header must be set.
This comment clarifies the behavior.

Fixes issue #79