### PR TITLE
Add GitHub action definition for conformance tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+output/
+conformance/vendor/

--- a/Dockerfile.conformance
+++ b/Dockerfile.conformance
@@ -1,0 +1,17 @@
+# ---
+# Stage 1: Install certs and build conformance binary
+# ---
+FROM docker.io/golang:1.13.6-alpine3.11 AS builder
+RUN apk --update add git make ca-certificates && \
+    mkdir -p /go/src/github.com/opencontainers/distribution-spec
+WORKDIR /go/src/github.com/opencontainers/distribution-spec
+ADD . .
+RUN make conformance-binary && mv output/conformance.test /conformance.test
+
+# ---
+# Stage 2: Final image with nothing but certs & binary
+# ---
+FROM scratch AS final
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /conformance.test /conformance.test
+ENTRYPOINT ["/conformance.test"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,11 @@
+name: OCI Distribution Spec Conformance Tests
+description: Validate a registry against the OCI Distribution Spec
+author: The Linux Foundation
+branding:
+  color: blue
+  icon: check-circle
+inputs: {}
+outputs: {}
+runs:
+  using: docker
+  image: Dockerfile.conformance

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -2,6 +2,8 @@
 
 ### How to Run
 
+#### Binary
+
 Requires Go 1.13+.
 
 In this directory, build the test binary:
@@ -28,3 +30,68 @@ Lastly, run the tests:
 This will produce `junit.xml` and `report.html` with the results.
 
 Note: for some registries, you may need to create `OCI_NAMESPACE` ahead of time.
+
+#### Container Image
+
+You may use [Dockerfile.conformance](./../Dockerfile.conformance) located at the
+root of this repo to build a container image that contains the test binary.
+
+Example (using `docker`):
+```
+# build the image
+(cd ../ && docker build -t conformance:latest -f Dockerfile.conformance .)
+
+# run the image
+docker run --rm \
+  -v $(pwd)/results:/results \
+  -w /results \
+  -e OCI_ROOT_URL="https://r.myreg.io" \
+  -e OCI_NAMESPACE="myorg/myrepo" \
+  -e OCI_USERNAME="myuser" \
+  -e OCI_PASSWORD="mypass" \
+  -e OCI_DEBUG="true" \
+  conformance:latest
+```
+
+This will create a local `results/` directory containing all of the test report files.
+
+#### GitHub Action
+
+A GitHub Action is provided by this repo which you can use
+as part of a GitHub-based CI pipeline.
+
+The following example will build the binary off of the master branch,
+run the tests, and upload `junit.xml` and `report.html` as build artifacts:
+
+```yaml
+# Place in repo at .github/workflows/oci-distribution-conformance.yml
+name: oci-distribution-conformance
+on: push
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run OCI Distribution Spec conformance tests
+        uses: opencontainers/distribution-spec@master
+        env:
+          OCI_ROOT_URL: https://myreg.io
+          OCI_NAMESPACE: mytestorg/mytestrepo
+          OCI_USERNAME: ${{ secrets.MY_REGISTRY_USERNAME }}
+          OCI_PASSWORD: ${{ secrets.MY_REGISTRY_PASSWORD }}
+      - run: mkdir -p .out/ && mv {report.html,junit.xml} .out/
+        if: always()
+      - name: Upload test results zip as build artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: oci-test-results-${{ github.sha }}
+          path: .out/
+        if: always()
+```
+
+You can also add a badge pointing to list of runs for this action using the following markdown:
+
+```
+[![](https://github.com/<org>/<repo>/workflows/oci-distribution-conformance/badge.svg)](https://github.com/<org>/<repo>/actions?query=workflow%3Aoci-distribution-conformance)
+```
+
+(replacing `<org>` and `<repo>` with your GitHub repo details).


### PR DESCRIPTION
Add action.yml as well as a Dockerfile for the conformance tests in order for others to easily run the against their registry as part of a GitHub-based CI pipeline.

Resolves #88
