### PR TITLE
Conformance: Add CI, new tests, more report detail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.11.x
+  - 1.13.x
 
 sudo: required
 
@@ -15,4 +15,4 @@ install: true
 script:
   - echo "${TRAVIS_COMMIT_RANGE} -> ${TRAVIS_COMMIT_RANGE/.../..} (travis-ci/travis-ci#4596)"
   - TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make .gitvalidation
-  - make docs
+  - make docs conformance

--- a/conformance/00_conformance_suite_test.go
+++ b/conformance/00_conformance_suite_test.go
@@ -16,8 +16,9 @@ func TestConformance(t *testing.T) {
 		test04BlobUploadChunked()
 		test05ManifestUpload()
 		test06TagsList()
-		test07ManifestDelete()
-		test08BlobDelete()
+		test07ErrorCodes()
+		test08ManifestDelete()
+		test09BlobDelete()
 	})
 	RegisterFailHandler(g.Fail)
 	reporters := []g.Reporter{newHTMLReporter(reportHTMLFilename), reporters.NewJUnitReporter(reportJUnitFilename)}

--- a/conformance/02_blob_upload_streamed_test.go
+++ b/conformance/02_blob_upload_streamed_test.go
@@ -14,9 +14,10 @@ var test02BlobUploadStreamed = func() {
 			req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
-			lastResponse = resp
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
 
-			req = client.NewRequest(reggie.PATCH, lastResponse.GetRelativeLocation()).
+			req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 				SetHeader("Content-Type", "application/octet-stream").
 				SetBody(blobA)
 			resp, err = client.Do(req)
@@ -33,6 +34,8 @@ var test02BlobUploadStreamed = func() {
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
 		})
 	})
 }

--- a/conformance/03_blob_upload_monolithic_test.go
+++ b/conformance/03_blob_upload_monolithic_test.go
@@ -18,6 +18,26 @@ var test03BlobUploadMonolithic = func() {
 			Expect(resp.StatusCode()).To(Equal(http.StatusNotFound))
 		})
 
+		g.Specify("POST request with digest and blob should yield a 201", func() {
+			req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/").
+				SetHeader("Content-Length", configContentLength).
+				SetHeader("Content-Type", "application/octet-stream").
+				SetQueryParam("digest", configDigest).
+				SetBody(configContent)
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
+			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+		})
+
+		g.Specify("GET request to blob URL from prior request should yield 200", func() {
+			req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configDigest))
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+		})
+
 		g.Specify("POST request should yield a session ID", func() {
 			req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 			resp, err := client.Do(req)
@@ -34,6 +54,8 @@ var test03BlobUploadMonolithic = func() {
 				SetBody(configContent)
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
 			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 		})
 

--- a/conformance/04_blob_upload_chunked_test.go
+++ b/conformance/04_blob_upload_chunked_test.go
@@ -10,14 +10,33 @@ import (
 
 var test04BlobUploadChunked = func() {
 	g.Context("Blob Upload Chunked", func() {
+		g.Specify("Out-of-order blob upload should return 416", func() {
+			req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/").
+				SetHeader("Content-Length", "0")
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
+
+			req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
+				SetHeader("Content-Type", "application/octet-stream").
+				SetHeader("Content-Length", blobBChunk2Length).
+				SetHeader("Content-Range", blobBChunk2Range).
+				SetBody(blobBChunk2)
+			resp, err = client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode()).To(Equal(http.StatusRequestedRangeNotSatisfiable))
+		})
+
 		g.Specify("PATCH request with first chunk should return 202", func() {
 			req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/").
 				SetHeader("Content-Length", "0")
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
-			lastResponse = resp
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
 
-			req = client.NewRequest(reggie.PATCH, lastResponse.GetRelativeLocation()).
+			req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 				SetHeader("Content-Type", "application/octet-stream").
 				SetHeader("Content-Length", blobBChunk1Length).
 				SetHeader("Content-Range", blobBChunk1Range).
@@ -37,6 +56,8 @@ var test04BlobUploadChunked = func() {
 				SetBody(blobBChunk2)
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
+			location := resp.Header().Get("Location")
+			Expect(location).ToNot(BeEmpty())
 			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 		})
 	})

--- a/conformance/05_manifest_upload_test.go
+++ b/conformance/05_manifest_upload_test.go
@@ -21,12 +21,18 @@ var test05ManifestUpload = func() {
 
 		g.Specify("PUT should accept a manifest upload", func() {
 			for i := 0; i < 4; i++ {
+				tag := fmt.Sprintf("test%d", i)
+				if i == 0 {
+					firstTag = tag
+				}
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
-					reggie.WithReference(fmt.Sprintf("test%d", i))).
+					reggie.WithReference(tag)).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
 					SetBody(manifestContent)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
+				location := resp.Header().Get("Location")
+				Expect(location).ToNot(BeEmpty())
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 			}
 		})

--- a/conformance/07_error_codes_test.go
+++ b/conformance/07_error_codes_test.go
@@ -1,0 +1,43 @@
+package conformance
+
+import (
+	"net/http"
+
+	"github.com/bloodorangeio/reggie"
+	g "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var test07ErrorCodes = func() {
+	g.Context("Error codes", func() {
+		g.Specify("400 response body should contain OCI-conforming JSON message", func() {
+			req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
+				reggie.WithReference("sha256:totallywrong")).
+				SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+				SetBody(invalidManifestContent)
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode()).To(Equal(http.StatusBadRequest))
+
+			errorResponses, err := resp.Errors()
+			Expect(err).To(BeNil())
+
+			Expect(errorResponses).ToNot(BeEmpty())
+			Expect(errorCodes).To(ContainElement(errorResponses[0].Code))
+		})
+
+		g.Specify("Response from DELETE request to manifest URL (tag) should have OCI-conforming code", func() {
+			req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>",
+				reggie.WithReference(firstTag))
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp).ToNot(BeNil())
+
+			errorResponses, err := resp.Errors()
+			Expect(err).To(BeNil())
+
+			Expect(errorResponses).ToNot(BeEmpty())
+			Expect(errorCodes).To(ContainElement(errorResponses[0].Code))
+		})
+	})
+}

--- a/conformance/08_manifest_delete_test.go
+++ b/conformance/08_manifest_delete_test.go
@@ -9,9 +9,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var test07ManifestDelete = func() {
+var test08ManifestDelete = func() {
 	g.Context("Manifest Delete", func() {
-		g.Specify("DELETE request to manifest URL should yield 202 response", func() {
+		g.Specify("DELETE request to manifest URL (tag) MUST fail", func() {
+			req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>",
+				reggie.WithReference(firstTag))
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode()).To(BeNumerically(">=", 400))
+			Expect(resp.StatusCode()).To(BeNumerically("<", 500))
+		})
+
+		g.Specify("GET request to manifest URL should reveal that delete failed", func() {
+			req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest)).
+				SetHeader("Accept", "application/vnd.oci.image.manifest.v1+json")
+			resp, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+		})
+
+		g.Specify("DELETE request to manifest URL (digest) should yield 202 response", func() {
 			req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())

--- a/conformance/09_blob_delete_test.go
+++ b/conformance/09_blob_delete_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var test08BlobDelete = func() {
+var test09BlobDelete = func() {
 	g.Context("Blob Delete", func() {
 		g.Specify("DELETE request to blob URL should yield 202 response", func() {
 			req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configDigest))

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -3,7 +3,7 @@ module github.com/opencontainers/distribution-spec/conformance
 go 1.13
 
 require (
-	github.com/bloodorangeio/reggie v0.3.1
+	github.com/bloodorangeio/reggie v0.3.2
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/opencontainers/go-digest v1.0.0-rc1

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -1,5 +1,5 @@
-github.com/bloodorangeio/reggie v0.3.1 h1:RQSDByCdJ6fyiOZ7PiNShG7H8CwK2YvXGFADhw2qDlw=
-github.com/bloodorangeio/reggie v0.3.1/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
+github.com/bloodorangeio/reggie v0.3.2 h1:lmxKmj9OF38Ql7/uqRHB5/hdrwv6AgSGO7oyMSB5/+E=
+github.com/bloodorangeio/reggie v0.3.2/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -18,35 +18,54 @@ type (
 )
 
 const (
-	nonexistentManifest string = ".INVALID_MANIFEST_NAME"
+	BLOB_UNKNOWN = iota
+	BLOB_UPLOAD_INVALID
+	BLOB_UPLOAD_UNKNOWN
+	DIGEST_INVALID
+	MANIFEST_BLOB_UNKNOWN
+	MANIFEST_INVALID
+	MANIFEST_UNKNOWN
+	MANIFEST_UNVERIFIED
+	NAME_INVALID
+	NAME_UNKNOWN
+	SIZE_INVALID
+	TAG_INVALID
+	UNAUTHORIZED
+	DENIED
+	UNSUPPORTED
 )
 
 var (
-	blobA               []byte
-	blobALength         string
-	blobADigest         string
-	blobB               []byte
-	blobBDigest         string
-	blobBChunk1         []byte
-	blobBChunk1Length   string
-	blobBChunk2         []byte
-	blobBChunk2Length   string
-	blobBChunk1Range    string
-	blobBChunk2Range    string
-	client              *reggie.Client
-	configContent       []byte
-	configContentLength string
-	configDigest        string
-	dummyDigest         string
-	lastResponse        *reggie.Response
-	lastTagList         TagList
-	manifestContent     []byte
-	manifestDigest      string
-	numTags             int
-	reportJUnitFilename string
-	reportHTMLFilename  string
-	httpWriter          *httpDebugWriter
-	suiteDescription    string
+	blobA                  []byte
+	blobALength            string
+	blobADigest            string
+	blobB                  []byte
+	blobBDigest            string
+	blobBChunk1            []byte
+	blobBChunk1Length      string
+	blobBChunk2            []byte
+	blobBChunk2Length      string
+	blobBChunk1Range       string
+	blobBChunk2Range       string
+	client                 *reggie.Client
+	configContent          []byte
+	configContentLength    string
+	configDigest           string
+	dummyDigest            string
+	errorCodes             []string
+	firstTag               string
+	lastResponse           *reggie.Response
+	lastTagList            TagList
+	manifestContent        []byte
+	invalidManifestContent []byte
+	manifestDigest         string
+	nonexistentManifest    string
+	numTags                int
+	reportJUnitFilename    string
+	reportHTMLFilename     string
+	httpWriter             *httpDebugWriter
+	suiteDescription       string
+	Version                = "unknown"
 )
 
 func init() {
@@ -80,6 +99,8 @@ func init() {
 			"\"schemaVersion\": 2 }",
 		configDigest, configContentLength))
 	manifestDigest = godigest.FromBytes(manifestContent).String()
+	nonexistentManifest = ".INVALID_MANIFEST_NAME"
+	invalidManifestContent = []byte("blablabla")
 
 	blobA = []byte("NBA Jam on my NBA toast")
 	blobALength = strconv.Itoa(len(blobA))
@@ -95,6 +116,24 @@ func init() {
 	blobBChunk2Range = fmt.Sprintf("%d-%d", len(blobBChunk1), len(blobB)-1)
 
 	dummyDigest = godigest.FromString("hello world").String()
+
+	errorCodes = []string{
+		BLOB_UNKNOWN:          "BLOB_UNKNOWN",
+		BLOB_UPLOAD_INVALID:   "BLOB_UPLOAD_INVALID",
+		BLOB_UPLOAD_UNKNOWN:   "BLOB_UPLOAD_UNKNOWN",
+		DIGEST_INVALID:        "DIGEST_INVALID",
+		MANIFEST_BLOB_UNKNOWN: "MANIFEST_BLOB_UNKNOWN",
+		MANIFEST_INVALID:      "MANIFEST_INVALID",
+		MANIFEST_UNKNOWN:      "MANIFEST_UNKNOWN",
+		MANIFEST_UNVERIFIED:   "MANIFEST_UNVERIFIED",
+		NAME_INVALID:          "NAME_INVALID",
+		NAME_UNKNOWN:          "NAME_UNKNOWN",
+		SIZE_INVALID:          "SIZE_INVALID",
+		TAG_INVALID:           "TAG_INVALID",
+		UNAUTHORIZED:          "UNAUTHORIZED",
+		DENIED:                "DENIED",
+		UNSUPPORTED:           "UNSUPPORTED",
+	}
 
 	reportJUnitFilename = "junit.xml"
 	reportHTMLFilename = "report.html"


### PR DESCRIPTION
Add new tests and generate more detailed report

Implement test for monolithic POST blob upload
The specification dictates:
"POST Initiate Blob Upload: Initiate a resumable blob upload. If
successful, an upload location will be provided to complete the upload.
Optionally, if the digest parameter is present, the request body will be
used to complete the upload in a single request."
https://github.com/opencontainers/distribution-spec/blob/master/spec.md#initiate-blob-upload

Implement test for manifest deletion by tag
The specification dictates:
"DELETE Manifest:
Delete the manifest identified by name and reference. Note that a
manifest can only be deleted by digest."

Modify check for JSON body
There was an error in the way improperly-parsed JSON was being handled.
This commit resolves that issue.

Add test for out-of-order chunked blob upload
As per the spec:
"There is no enforcement on layer chunk splits other than that the
server MUST receive them in order. The server MAY enforce a minimum
chunk size. If the server cannot accept the chunk, a 416 Requested
Range Not Satisfiable response will be returned and will include a
Range header indicating the current status:"

Resolves #87

Improve HTML report
HTML report now shows a summary of passes, failures, environment
variables and timestamps.

Resolves #84

Include commit hash of version used to compile binary in HTML report.
Resolves #91

Update travis and makefile to run linter against conformance tests
Resolves #83 
