### PR TITLE
Move Dockerfile to conformance directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,4 +8,4 @@ inputs: {}
 outputs: {}
 runs:
   using: docker
-  image: Dockerfile
+  image: conformance/Dockerfile

--- a/conformance/Dockerfile
+++ b/conformance/Dockerfile
@@ -1,14 +1,13 @@
-# Note: this Dockerfile is used for running conformance tests
-
 # ---
 # Stage 1: Install certs and build conformance binary
 # ---
 FROM docker.io/golang:1.13.6-alpine3.11 AS builder
-RUN apk --update add git make ca-certificates && \
-    mkdir -p /go/src/github.com/opencontainers/distribution-spec
-WORKDIR /go/src/github.com/opencontainers/distribution-spec
+ARG VERSION=unknown
+ARG GO_PKG=github.com/opencontainers/distribution-spec/conformance
+RUN apk --update add git make ca-certificates && mkdir -p /go/src/${GO_PKG}
+WORKDIR /go/src/${GO_PKG}
 ADD . .
-RUN make conformance-binary && mv output/conformance.test /conformance.test
+RUN CGO_ENABLED=0 go test -c -o /conformance.test --ldflags="-X ${GO_PKG}.Version=${VERSION}"
 
 # ---
 # Stage 2: Final image with nothing but certs & binary

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -33,13 +33,14 @@ Note: for some registries, you may need to create `OCI_NAMESPACE` ahead of time.
 
 #### Container Image
 
-You may use [Dockerfile](./../Dockerfile) located at the
-root of this repo to build a container image that contains the test binary.
+You may use the [Dockerfile](./Dockerfile) located in this directory
+to build a container image that contains the test binary.
 
 Example (using `docker`):
 ```
-# build the image
-(cd ../ && docker build -t conformance:latest -f Dockerfile .)
+# build the image, using git SHA as the version
+docker build -t conformance:latest \
+    --build-arg VERSION=$(git log --format="%H" -n 1) .
 
 # run the image
 docker run --rm \


### PR DESCRIPTION
In order to prevent confusion about the purpose of the Dockerfile,
move it into conformance directory where it is more appropriate.

Also remove dependency on Makefile, and instead using build args
to pass along the test version that is visible in report.html.

Resolves #99.
