### PR TITLE
Allow range of response codes for manifest delete

### DIFF
--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -36,9 +36,12 @@ const (
       pre.fail-message {
         background: #f9a5a5;
         padding: 20px;
+        margin-right: 10px;
         display: inline-block;
         border-radius: 4px;
         font-size: 1.25em;
+        width: 94%;
+        overflow-x: auto;
       }
       .green {
         background: #c8ffc8;


### PR DESCRIPTION
Resolves #102.  The revised test checks for one of three
responses: 202 Accepted, 400 Bad Request, or 405 Method Not Allowed.  If
the response is 400 Bad Request, an additional check is triggered to
verify an OCI-Conformant code is returned, in this case "UNSUPPORTED".

Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>