### PR TITLE
Prevent test from panicking

### DIFF
--- a/conformance/06_tags_list_test.go
+++ b/conformance/06_tags_list_test.go
@@ -51,14 +51,19 @@ var test06TagsList = func() {
 			err = json.Unmarshal(jsonData, tagList)
 			Expect(err).To(BeNil())
 			Expect(len(tagList.Tags)).To(Equal(numResults))
-			lastTagList = *tagList
+			lastTagList = &TagList{
+				Name: tagList.Name,
+				Tags: tagList.Tags,
+			}
 		})
 
 		g.Specify("GET start of tag is set by `last` query parameter", func() {
 			numResults := numTags / 2
+			Expect(len(lastTagList.Tags)).To(BeNumerically(">=", 0))
+			lastTag := lastTagList.Tags[numResults-1]
 			req := client.NewRequest(reggie.GET, "/v2/<name>/tags/list").
 				SetQueryParam("n", strconv.Itoa(numResults)).
-				SetQueryParam("last", lastTagList.Tags[numResults-1])
+				SetQueryParam("last", lastTag)
 			resp, err := client.Do(req)
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode()).To(Equal(http.StatusOK))

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -55,7 +55,7 @@ var (
 	errorCodes             []string
 	firstTag               string
 	lastResponse           *reggie.Response
-	lastTagList            TagList
+	lastTagList            *TagList
 	manifestContent        []byte
 	invalidManifestContent []byte
 	manifestDigest         string


### PR DESCRIPTION
Currently, depending on the tags returned from the registry, one of the
tests in conformance/06_tags_list_test.go will panic. When this happens,
it is removed from the report. Resolves #112 

Signed-off-by: Peter Engelbert <pmengelbert@gmail.com>