### PR TITLE
Upload a layer to be included in the manifest

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -29,7 +29,7 @@ var test02Push = func() {
 
 				req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetBody(blobA)
+					SetBody(testBlobA)
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
@@ -39,9 +39,9 @@ var test02Push = func() {
 			g.Specify("PUT request to session URL with digest should yield 201 response", func() {
 				SkipIfDisabled(push)
 				req := client.NewRequest(reggie.PUT, lastResponse.GetRelativeLocation()).
-					SetQueryParam("digest", blobADigest).
+					SetQueryParam("digest", testBlobADigest).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", blobALength)
+					SetHeader("Content-Length", testBlobALength)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
@@ -63,10 +63,10 @@ var test02Push = func() {
 			g.Specify("POST request with digest and blob should yield a 201", func() {
 				SkipIfDisabled(push)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/").
-					SetHeader("Content-Length", configContentLength).
+					SetHeader("Content-Length", configBlobContentLength).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetQueryParam("digest", blobDigest).
-					SetBody(configContent)
+					SetQueryParam("digest", configBlobDigest).
+					SetBody(configBlobContent)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				location := resp.Header().Get("Location")
@@ -76,7 +76,7 @@ var test02Push = func() {
 
 			g.Specify("GET request to blob URL from prior request should yield 200", func() {
 				SkipIfDisabled(push)
-				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
+				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
@@ -94,10 +94,10 @@ var test02Push = func() {
 			g.Specify("PUT upload of a blob should yield a 201 Response", func() {
 				SkipIfDisabled(push)
 				req := client.NewRequest(reggie.PUT, lastResponse.GetRelativeLocation()).
-					SetHeader("Content-Length", configContentLength).
+					SetHeader("Content-Length", configBlobContentLength).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetQueryParam("digest", blobDigest).
-					SetBody(configContent)
+					SetQueryParam("digest", configBlobDigest).
+					SetBody(configBlobContent)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				location := resp.Header().Get("Location")
@@ -107,7 +107,32 @@ var test02Push = func() {
 
 			g.Specify("GET request to existing blob should yield 200 response", func() {
 				SkipIfDisabled(push)
-				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
+				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			})
+
+			g.Specify("PUT upload of a layer blob should yield a 201 Response", func() {
+				SkipIfDisabled(push)
+				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
+					SetHeader("Content-Length", layerBlobContentLength).
+					SetHeader("Content-Type", "application/octet-stream").
+					SetQueryParam("digest", layerBlobDigest).
+					SetBody(layerBlobData)
+				resp, err = client.Do(req)
+				Expect(err).To(BeNil())
+				location := resp.Header().Get("Location")
+				Expect(location).ToNot(BeEmpty())
+				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			})
+
+			g.Specify("GET request to existing layer should yield 200 response", func() {
+				SkipIfDisabled(push)
+				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
@@ -126,9 +151,9 @@ var test02Push = func() {
 
 				req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", blobBChunk2Length).
-					SetHeader("Content-Range", blobBChunk2Range).
-					SetBody(blobBChunk2)
+					SetHeader("Content-Length", testBlobBChunk2Length).
+					SetHeader("Content-Range", testBlobBChunk2Range).
+					SetBody(testBlobBChunk2)
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusRequestedRangeNotSatisfiable))
@@ -145,9 +170,9 @@ var test02Push = func() {
 
 				req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", blobBChunk1Length).
-					SetHeader("Content-Range", blobBChunk1Range).
-					SetBody(blobBChunk1)
+					SetHeader("Content-Length", testBlobBChunk1Length).
+					SetHeader("Content-Range", testBlobBChunk1Range).
+					SetBody(testBlobBChunk1)
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
@@ -157,11 +182,11 @@ var test02Push = func() {
 			g.Specify("PUT request with final chunk should return 201", func() {
 				SkipIfDisabled(push)
 				req := client.NewRequest(reggie.PUT, lastResponse.GetRelativeLocation()).
-					SetHeader("Content-Length", blobBChunk2Length).
-					SetHeader("Content-Range", blobBChunk2Range).
+					SetHeader("Content-Length", testBlobBChunk2Length).
+					SetHeader("Content-Range", testBlobBChunk2Range).
 					SetHeader("Content-Type", "application/octet-stream").
-					SetQueryParam("digest", blobBDigest).
-					SetBody(blobBChunk2)
+					SetQueryParam("digest", testBlobBDigest).
+					SetBody(testBlobBChunk2)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				location := resp.Header().Get("Location")
@@ -207,10 +232,23 @@ var test02Push = func() {
 		})
 
 		g.Context("Teardown", func() {
-			g.Specify("Delete blob created in tests", func() {
+			g.Specify("Delete config blob created in tests", func() {
+				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
 				SkipIfDisabled(contentManagement)
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
+				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(SatisfyAll(
+					BeNumerically(">=", 200),
+					BeNumerically("<", 300)))
+			})
+
+			g.Specify("Delete layer blob created in setup", func() {
+				SkipIfDisabled(push)
+				RunOnlyIf(runPushSetup)
+				SkipIfDisabled(contentManagement)
+				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(SatisfyAll(
@@ -219,6 +257,7 @@ var test02Push = func() {
 			})
 
 			g.Specify("Delete manifest created in tests", func() {
+				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -221,6 +221,19 @@ var test02Push = func() {
 				}
 			})
 
+			g.Specify("Registry should accept a manifest upload with no layers", func() {
+				RunOnlyIf(!skipEmptyLayerTest)
+				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
+					reggie.WithReference(emptyLayerTestTag)).
+					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+					SetBody(emptyLayerManifestContent)
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				location := resp.Header().Get("Location")
+				Expect(location).ToNot(BeEmpty())
+				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			})
+
 			g.Specify("GET request to manifest URL (digest) should yield 200 response", func() {
 				SkipIfDisabled(push)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest)).

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -84,11 +84,14 @@ Some registries may require a workaround for Authorization during the push flow.
 OCI_AUTH_SCOPE="repository:mystuff/myrepo:pull,push"
 ```
 
-Some registries currently require at least one layer to be uploaded (and referenced in the appropriate section of the manifest) before a manifest upload will succeed. By default, the layers section of the manifest will be empty. If a workaround is needed, you may set the following in the environment:
+Most registries currently require at least one layer to be uploaded (and referenced in the appropriate section of the manifest)
+before a manifest upload will succeed. By default, the push tests will attempt to push two manifests: one with a single layer,
+and another with no layers. If the empty-layer test is causing a failure, it can be skipped by setting the following in the
+environment:
 
 ```
 # Enable layer upload
-OCI_UPLOAD_LAYER=1
+OCI_SKIP_EMPTY_LAYER_PUSH_TEST=1
 ```
 
 ##### Content Discovery

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -77,6 +77,20 @@ To enable the Push tests, you must explicitly set the following in the environme
 OCI_TEST_PUSH=1
 ```
 
+Some registries may require a workaround for Authorization during the push flow. To set your own scope, set the following in the environment:
+
+```
+# Set the auth scope
+OCI_AUTH_SCOPE="repository:mystuff/myrepo:pull,push"
+```
+
+Some registries currently require at least one layer to be uploaded (and referenced in the appropriate section of the manifest) before a manifest upload will succeed. By default, the layers section of the manifest will be empty. If a workaround is needed, you may set the following in the environment:
+
+```
+# Enable layer upload
+OCI_UPLOAD_LAYER=1
+```
+
 ##### Content Discovery
 
 The Content Discovery tests validate that the contents of a registry can be discovered.

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.1
 )

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -3,7 +3,7 @@ module github.com/opencontainers/distribution-spec/conformance
 go 1.13
 
 require (
-	github.com/bloodorangeio/reggie v0.3.3
+	github.com/bloodorangeio/reggie v0.4.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/opencontainers/go-digest v1.0.0-rc1

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -3,7 +3,7 @@ module github.com/opencontainers/distribution-spec/conformance
 go 1.13
 
 require (
-	github.com/bloodorangeio/reggie v0.3.2
+	github.com/bloodorangeio/reggie v0.3.3
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/opencontainers/go-digest v1.0.0-rc1

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -1,5 +1,5 @@
-github.com/bloodorangeio/reggie v0.3.3 h1:ZL4hV5X+HAS3o9RNrvljlpvvtpVlc7fEzDv6ykur8UI=
-github.com/bloodorangeio/reggie v0.3.3/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
+github.com/bloodorangeio/reggie v0.4.0 h1:x4Y4gsC9qcFcQASEwME3frs9bWAHGb3EfsRWwdnwxSg=
+github.com/bloodorangeio/reggie v0.4.0/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -19,6 +19,8 @@ github.com/opencontainers/distribution-spec v1.0.0-rc0.0.20200108182153-219f20cb
 github.com/opencontainers/distribution-spec v1.0.0-rc0.0.20200108182153-219f20cbcfa1/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
+github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -1,5 +1,5 @@
-github.com/bloodorangeio/reggie v0.3.2 h1:lmxKmj9OF38Ql7/uqRHB5/hdrwv6AgSGO7oyMSB5/+E=
-github.com/bloodorangeio/reggie v0.3.2/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
+github.com/bloodorangeio/reggie v0.3.3 h1:ZL4hV5X+HAS3o9RNrvljlpvvtpVlc7fEzDv6ykur8UI=
+github.com/bloodorangeio/reggie v0.3.3/go.mod h1:u7HqihAZy812d6ysiuDawpHJYtpGSNL2E/4Cyu/mtZg=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -2,8 +2,10 @@ package conformance
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 
@@ -57,6 +59,14 @@ const (
 	push
 	contentDiscovery
 	contentManagement
+
+	// layerBase64String is a base64 encoding of a simple tarball, obtained like this:
+	// 		$ echo 'you bothered to find out what was in here. Congratulations!' > test.txt
+	// 		$ tar czvf test.tar.gz test.txt
+	// 		$ cat test.tar.gz | base64
+	layerBase64String = "H4sIAAAAAAAAA+3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0" +
+		"WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd+qD" +
+		"jMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA"
 )
 
 var (
@@ -67,25 +77,28 @@ var (
 		envVarContentManagement: contentManagement,
 	}
 
-	blobA                     []byte
-	blobALength               string
-	blobADigest               string
-	blobB                     []byte
-	blobBDigest               string
-	blobBChunk1               []byte
-	blobBChunk1Length         string
-	blobBChunk2               []byte
-	blobBChunk2Length         string
-	blobBChunk1Range          string
-	blobBChunk2Range          string
-	blobDigest                string
+	testBlobA                 []byte
+	testBlobALength           string
+	testBlobADigest           string
+	testBlobB                 []byte
+	testBlobBDigest           string
+	testBlobBChunk1           []byte
+	testBlobBChunk1Length     string
+	testBlobBChunk2           []byte
+	testBlobBChunk2Length     string
+	testBlobBChunk1Range      string
+	testBlobBChunk2Range      string
+	configBlobDigest          string
 	client                    *reggie.Client
-	configContent             []byte
-	configContentLength       string
+	configBlobContent         []byte
+	configBlobContentLength   string
 	dummyDigest               string
 	errorCodes                []string
 	manifestContent           []byte
 	invalidManifestContent    []byte
+	layerBlobData             []byte
+	layerBlobDigest           string
+	layerBlobContentLength    string
 	manifestDigest            string
 	nonexistentManifest       string
 	reportJUnitFilename       string
@@ -101,10 +114,13 @@ var (
 )
 
 func init() {
+	var err error
+
 	hostname := os.Getenv("OCI_ROOT_URL")
 	namespace := os.Getenv("OCI_NAMESPACE")
 	username := os.Getenv("OCI_USERNAME")
 	password := os.Getenv("OCI_PASSWORD")
+	authScope := os.Getenv(envVarAuthScope)
 	debug := os.Getenv("OCI_DEBUG") == "true"
 
 	for envVar, enableTest := range testMap {
@@ -113,22 +129,21 @@ func init() {
 		}
 	}
 
-	var err error
-
 	httpWriter = newHTTPDebugWriter(debug)
 	logger := newHTTPDebugLogger(httpWriter)
 	client, err = reggie.NewClient(hostname,
 		reggie.WithDefaultName(namespace),
 		reggie.WithUsernamePassword(username, password),
 		reggie.WithDebug(true),
-		reggie.WithUserAgent("distribution-spec-conformance-tests"))
+		reggie.WithUserAgent("distribution-spec-conformance-tests"),
+		reggie.WithAuthScope(authScope))
 	if err != nil {
 		panic(err)
 	}
 
 	client.SetLogger(logger)
 
-	configContent = []byte(`
+	configBlobContent = []byte(`
 {
     "architecture": "amd64",
     "os": "linux",
@@ -138,17 +153,38 @@ func init() {
     }
 }
 `)
-	configContentLength = strconv.Itoa(len(configContent))
-	blobDigest = godigest.FromBytes(configContent).String()
+	configBlobContentLength = strconv.Itoa(len(configBlobContent))
+	configBlobDigest = godigest.FromBytes(configBlobContent).String()
 	if v := os.Getenv(envVarBlobDigest); v != "" {
-		blobDigest = v
+		configBlobDigest = v
 	}
 
-	manifestContent = []byte(fmt.Sprintf(
-		"{ \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\", \"config\":  { \"digest\": \"%s\", "+
-			"\"mediaType\": \"application/vnd.oci.image.config.v1+json\","+" \"size\": %s }, \"layers\": [], "+
-			"\"schemaVersion\": 2 }",
-		blobDigest, configContentLength))
+	layerBlobData, err = base64.StdEncoding.DecodeString(layerBase64String)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	layerBlobDigest = godigest.FromBytes(layerBlobData).String()
+	layerBlobContentLength = fmt.Sprintf("%d", len(layerBlobData))
+
+	manifestContent = []byte(fmt.Sprintf(`
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config":  {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": %s,
+    "digest": "%s"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "size": %s,
+      "digest": "%s"
+    }
+  ],
+  "schemaVersion": 2
+}`, configBlobContentLength, configBlobDigest, layerBlobContentLength, layerBlobDigest))
+
 	manifestDigest = godigest.FromBytes(manifestContent).String()
 	if v := os.Getenv(envVarManifestDigest); v != "" {
 		manifestDigest = v
@@ -156,18 +192,18 @@ func init() {
 	nonexistentManifest = ".INVALID_MANIFEST_NAME"
 	invalidManifestContent = []byte("blablabla")
 
-	blobA = []byte("NBA Jam on my NBA toast")
-	blobALength = strconv.Itoa(len(blobA))
-	blobADigest = godigest.FromBytes(blobA).String()
+	testBlobA = []byte("NBA Jam on my NBA toast")
+	testBlobALength = strconv.Itoa(len(testBlobA))
+	testBlobADigest = godigest.FromBytes(testBlobA).String()
 
-	blobB = []byte("Hello, how are you today?")
-	blobBDigest = godigest.FromBytes(blobB).String()
-	blobBChunk1 = blobB[:3]
-	blobBChunk1Length = strconv.Itoa(len(blobBChunk1))
-	blobBChunk1Range = fmt.Sprintf("0-%d", len(blobBChunk1)-1)
-	blobBChunk2 = blobB[3:]
-	blobBChunk2Length = strconv.Itoa(len(blobBChunk2))
-	blobBChunk2Range = fmt.Sprintf("%d-%d", len(blobBChunk1), len(blobB)-1)
+	testBlobB = []byte("Hello, how are you today?")
+	testBlobBDigest = godigest.FromBytes(testBlobB).String()
+	testBlobBChunk1 = testBlobB[:3]
+	testBlobBChunk1Length = strconv.Itoa(len(testBlobBChunk1))
+	testBlobBChunk1Range = fmt.Sprintf("0-%d", len(testBlobBChunk1)-1)
+	testBlobBChunk2 = testBlobB[3:]
+	testBlobBChunk2Length = strconv.Itoa(len(testBlobBChunk2))
+	testBlobBChunk2Range = fmt.Sprintf("%d-%d", len(testBlobBChunk1), len(testBlobB)-1)
 
 	dummyDigest = godigest.FromString("hello world").String()
 


### PR DESCRIPTION
There is a base64 enoded string which, when decoded, contains a tarball.
This is uploaded as a blob and then included in the `"layers": []`
section of the manifest. Some registries were rejecting the manifest due
to an empty layers section, so this fix should resolve that issue.

Resolves #118