### PR TITLE
Allow disabling 'pull' workflow

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -17,6 +17,7 @@ var test01Pull = func() {
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test blob", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, _ := client.Do(req)
@@ -33,6 +34,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Populate registry with test manifest", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				tag := testTagName
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
@@ -47,6 +49,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Get the name of a tag", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/tags/list")
 				resp, _ := client.Do(req)
@@ -54,6 +57,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Get tag name from environment", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIfNot(runPullSetup)
 				tag = os.Getenv(envVarTagName)
 			})
@@ -61,6 +65,7 @@ var test01Pull = func() {
 
 		g.Context("Pull blobs", func() {
 			g.Specify("GET nonexistent blob should result in 404 response", func() {
+				SkipIfDisabled(pull)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>",
 					reggie.WithDigest(dummyDigest))
 				resp, err := client.Do(req)
@@ -69,6 +74,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("GET request to existing blob URL should yield 200", func() {
+				SkipIfDisabled(pull)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -78,6 +84,7 @@ var test01Pull = func() {
 
 		g.Context("Pull manifests", func() {
 			g.Specify("GET nonexistent manifest should return 404", func() {
+				SkipIfDisabled(pull)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(nonexistentManifest))
 				resp, err := client.Do(req)
@@ -86,6 +93,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("GET request to manifest path (digest) should yield 200 response", func() {
+				SkipIfDisabled(pull)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest)).
 					SetHeader("Accept", "application/vnd.oci.image.manifest.v1+json")
 				resp, err := client.Do(req)
@@ -94,6 +102,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("GET request to manifest path (tag) should yield 200 response", func() {
+				SkipIfDisabled(pull)
 				Expect(tag).ToNot(BeEmpty())
 				req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<reference>", reggie.WithReference(tag)).
 					SetHeader("Accept", "application/vnd.oci.image.manifest.v1+json")
@@ -105,6 +114,7 @@ var test01Pull = func() {
 
 		g.Context("Error codes", func() {
 			g.Specify("400 response body should contain OCI-conforming JSON message", func() {
+				SkipIfDisabled(pull)
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference("sha256:totallywrong")).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
@@ -126,6 +136,7 @@ var test01Pull = func() {
 
 		g.Context("Teardown", func() {
 			g.Specify("Delete blob created in setup", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
@@ -137,6 +148,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Delete manifest created in setup", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -208,7 +208,7 @@ var test02Push = func() {
 
 		g.Context("Teardown", func() {
 			g.Specify("Delete blob created in tests", func() {
-				RunOnlyIf(runPullSetup)
+				RunOnlyIf(runPushSetup)
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
 				resp, err := client.Do(req)
@@ -219,7 +219,7 @@ var test02Push = func() {
 			})
 
 			g.Specify("Delete manifest created in tests", func() {
-				RunOnlyIf(runPullSetup)
+				RunOnlyIf(runPushSetup)
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -49,7 +49,10 @@ In addition, each category has its own setup and teardown processes where approp
 
 The Pull tests validate that content can be retrieved from a registry.
 
-These tests are *always* run, as this is the baseline for registry conformance.
+These tests are run when the following is set in the environment:
+```
+OCI_TEST_PULL=1
+```
 
 Regardless of whether the Push tests are enabled, as part of setup for the Pull tests,
 content will be uploaded to the registry.

--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -446,7 +446,7 @@ func newHTMLReporter(htmlReportFilename string) (h *HTMLReporter) {
 
 	if os.Getenv(envVarHideSkippedWorkflows) == "1" {
 		enabledMap = map[string]bool{
-			titlePull:              true,
+			titlePull:              !userDisabled(pull),
 			titlePush:              !userDisabled(push),
 			titleContentDiscovery:  !userDisabled(contentDiscovery),
 			titleContentManagement: !userDisabled(contentManagement),

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -37,6 +37,7 @@ const (
 	UNSUPPORTED
 
 	envTrue                    = "1"
+	envVarPull                 = "OCI_TEST_PULL"
 	envVarPush                 = "OCI_TEST_PUSH"
 	envVarContentDiscovery     = "OCI_TEST_CONTENT_DISCOVERY"
 	envVarContentManagement    = "OCI_TEST_CONTENT_MANAGEMENT"
@@ -52,13 +53,15 @@ const (
 	titleContentDiscovery  = "Content Discovery"
 	titleContentManagement = "Content Management"
 
-	push = 1 << iota
+	pull = 1 << iota
+	push
 	contentDiscovery
 	contentManagement
 )
 
 var (
 	testMap = map[string]int{
+		envVarPull:              pull,
 		envVarPush:              push,
 		envVarContentDiscovery:  contentDiscovery,
 		envVarContentManagement: contentManagement,


### PR DESCRIPTION
By setting `OCI_TEST_PULL=1` in the environment, the pull tests can be
run. This, in combination with hiding disabled workflows from the
report, allows for true separation of each workflow. A separate report
can be generated for each.

Resolves #135.