### PR TITLE
Disable push teardown on Content Management workflow (BROKEN)

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -138,7 +138,6 @@ var test01Pull = func() {
 			g.Specify("Delete blob created in setup", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -150,7 +149,6 @@ var test01Pull = func() {
 			g.Specify("Delete manifest created in setup", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -208,8 +208,8 @@ var test02Push = func() {
 
 		g.Context("Teardown", func() {
 			g.Specify("Delete blob created in tests", func() {
+				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(blobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -219,8 +219,8 @@ var test02Push = func() {
 			})
 
 			g.Specify("Delete manifest created in tests", func() {
+				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -222,7 +222,8 @@ var test02Push = func() {
 			})
 
 			g.Specify("Registry should accept a manifest upload with no layers", func() {
-				RunOnlyIf(!skipEmptyLayerTest)
+				SkipIfDisabled(push)
+				RunOnlyIfNot(skipEmptyLayerTest)
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(emptyLayerTestTag)).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -20,8 +20,8 @@ var test03ContentDiscovery = func() {
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test tags", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
+				RunOnlyIf(runContentDiscoverySetup)
 				for i := 0; i < numTags; i++ {
 					tag := fmt.Sprintf("test%d", i)
 					tagList = append(tagList, tag)
@@ -42,8 +42,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Populate registry with test tags (no push)", func() {
-				RunOnlyIfNot(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
+				RunOnlyIfNot(runContentDiscoverySetup)
 				tagList = strings.Split(os.Getenv(envVarTagList), ",")
 			})
 		})
@@ -94,9 +94,8 @@ var test03ContentDiscovery = func() {
 
 		g.Context("Teardown", func() {
 			g.Specify("Delete created manifest & associated tags", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
-				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/04_management_test.go
+++ b/conformance/04_management_test.go
@@ -18,8 +18,8 @@ var test04ContentManagement = func() {
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test blob", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, _ := client.Do(req)
 
@@ -36,8 +36,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("Populate registry with test tag", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				tagToDelete = defaultTagName
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(tagToDelete)).
@@ -51,8 +51,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("Check how many tags there are before anything gets deleted", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/tags/list")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -15,11 +15,21 @@ This will produce an executable at `conformance.test`.
 
 Next, set environment variables with your registry details:
 ```
+# Registry details
 export OCI_ROOT_URL="https://r.myreg.io"
 export OCI_NAMESPACE="myorg/myrepo"
 export OCI_USERNAME="myuser"
 export OCI_PASSWORD="mypass"
-export OCI_DEBUG="true"
+
+# Which workflows to run
+export OCI_TEST_PULL=1
+export OCI_TEST_PUSH=1
+export OCI_TEST_CONTENT_DISCOVERY=1
+export OCI_TEST_CONTENT_MANAGEMENT=1
+
+# Extra settings
+export OCI_HIDE_SKIPPED_WORKFLOWS=0
+export OCI_DEBUG=0
 ```
 
 Lastly, run the tests:
@@ -139,7 +149,12 @@ docker run --rm \
   -e OCI_NAMESPACE="myorg/myrepo" \
   -e OCI_USERNAME="myuser" \
   -e OCI_PASSWORD="mypass" \
-  -e OCI_DEBUG="true" \
+  -e OCI_TEST_PULL=1 \
+  -e OCI_TEST_PUSH=1 \
+  -e OCI_TEST_CONTENT_DISCOVERY=1 \
+  -e OCI_TEST_CONTENT_MANAGEMENT=1 \
+  -e OCI_HIDE_SKIPPED_WORKFLOWS=0
+  -e OCI_DEBUG=0 \
   conformance:latest
 ```
 
@@ -168,6 +183,12 @@ jobs:
           OCI_NAMESPACE: mytestorg/mytestrepo
           OCI_USERNAME: ${{ secrets.MY_REGISTRY_USERNAME }}
           OCI_PASSWORD: ${{ secrets.MY_REGISTRY_PASSWORD }}
+          OCI_TEST_PULL: 1
+          OCI_TEST_PUSH: 1
+          OCI_TEST_CONTENT_DISCOVERY: 1
+          OCI_TEST_CONTENT_MANAGEMENT: 1
+          OCI_HIDE_SKIPPED_WORKFLOWS: 0
+          OCI_DEBUG: 0
       - run: mkdir -p .out/ && mv {report.html,junit.xml} .out/
         if: always()
       - name: Upload test results zip as build artifact

--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -538,11 +538,12 @@ func (reporter *HTMLReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 //unused by HTML reporter
 func (reporter *HTMLReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
 	varsToCheck := []string{
-		"OCI_ROOT_URL",
-		"OCI_NAMESPACE",
-		"OCI_DEBUG",
-		"OCI_PASSWORD",
-		"OCI_USERNAME",
+		envVarRootURL,
+		envVarNamespace,
+		envVarUsername,
+		envVarPassword,
+		envVarDebug,
+		envVarPull,
 		envVarPush,
 		envVarContentDiscovery,
 		envVarContentManagement,
@@ -550,6 +551,7 @@ func (reporter *HTMLReporter) SpecSuiteWillBegin(config config.GinkgoConfigType,
 		envVarManifestDigest,
 		envVarTagName,
 		envVarTagList,
+		envVarHideSkippedWorkflows,
 	}
 	for _, v := range varsToCheck {
 		var replacement string

--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -547,11 +547,14 @@ func (reporter *HTMLReporter) SpecSuiteWillBegin(config config.GinkgoConfigType,
 		envVarPush,
 		envVarContentDiscovery,
 		envVarContentManagement,
+		envVarPushEmptyLayer,
 		envVarBlobDigest,
 		envVarManifestDigest,
+		envVarEmptyLayerManifestDigest,
 		envVarTagName,
 		envVarTagList,
 		envVarHideSkippedWorkflows,
+		envVarAuthScope,
 	}
 	for _, v := range varsToCheck {
 		var replacement string

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -36,7 +36,13 @@ const (
 	DENIED
 	UNSUPPORTED
 
-	envTrue                    = "1"
+	envTrue = "1"
+
+	envVarRootURL              = "OCI_ROOT_URL"
+	envVarNamespace            = "OCI_NAMESPACE"
+	envVarUsername             = "OCI_USERNAME"
+	envVarPassword             = "OCI_PASSWORD"
+	envVarDebug                = "OCI_DEBUG"
 	envVarPull                 = "OCI_TEST_PULL"
 	envVarPush                 = "OCI_TEST_PUSH"
 	envVarContentDiscovery     = "OCI_TEST_CONTENT_DISCOVERY"
@@ -46,7 +52,8 @@ const (
 	envVarTagName              = "OCI_TAG_NAME"
 	envVarTagList              = "OCI_TAG_LIST"
 	envVarHideSkippedWorkflows = "OCI_HIDE_SKIPPED_WORKFLOWS"
-	testTagName                = "tagtest0"
+
+	testTagName = "tagtest0"
 
 	titlePull              = "Pull"
 	titlePush              = "Push"
@@ -101,11 +108,11 @@ var (
 )
 
 func init() {
-	hostname := os.Getenv("OCI_ROOT_URL")
-	namespace := os.Getenv("OCI_NAMESPACE")
-	username := os.Getenv("OCI_USERNAME")
-	password := os.Getenv("OCI_PASSWORD")
-	debug := os.Getenv("OCI_DEBUG") == "true"
+	hostname := os.Getenv(envVarRootURL)
+	namespace := os.Getenv(envVarNamespace)
+	username := os.Getenv(envVarUsername)
+	password := os.Getenv(envVarPassword)
+	debug := os.Getenv(envVarDebug) == envTrue
 
 	for envVar, enableTest := range testMap {
 		if os.Getenv(envVar) == envTrue {


### PR DESCRIPTION
Also includes several minor changes:

- Change debug truthy var to "1" vs "true"
- Add constants for env vars like OCI_ROOT_URL
- Ensure all OCI_ vars are displayed in HTML report
- Update README to reflect new workflow env vars

Resolves #141.
Resolves #140.
