### PR TITLE
Disable push teardown on Content Management workflow

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -34,6 +34,7 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Populate registry with test layer", func() {
+				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, _ := client.Do(req)
@@ -154,7 +155,6 @@ var test01Pull = func() {
 			g.Specify("Delete config blob created in setup", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -164,9 +164,8 @@ var test01Pull = func() {
 			})
 
 			g.Specify("Delete layer blob created in setup", func() {
-				RunOnlyIf(runPullSetup)
 				SkipIfDisabled(pull)
-				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runPullSetup)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -178,7 +177,6 @@ var test01Pull = func() {
 			g.Specify("Delete manifest created in setup", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -222,7 +222,8 @@ var test02Push = func() {
 			})
 
 			g.Specify("Registry should accept a manifest upload with no layers", func() {
-				RunOnlyIf(!skipEmptyLayerTest)
+				SkipIfDisabled(push)
+				RunOnlyIfNot(skipEmptyLayerTest)
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(emptyLayerTestTag)).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
@@ -248,7 +249,6 @@ var test02Push = func() {
 			g.Specify("Delete config blob created in tests", func() {
 				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -260,7 +260,6 @@ var test02Push = func() {
 			g.Specify("Delete layer blob created in setup", func() {
 				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -272,7 +271,6 @@ var test02Push = func() {
 			g.Specify("Delete manifest created in tests", func() {
 				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -281,6 +279,5 @@ var test02Push = func() {
 					BeNumerically("<", 300)))
 			})
 		})
-
 	})
 }

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -20,8 +20,8 @@ var test03ContentDiscovery = func() {
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test blob", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -38,8 +38,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Populate registry with test layer", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -56,9 +56,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Populate registry with test tags", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
-
+				RunOnlyIf(runContentDiscoverySetup)
 				for i := 0; i < numTags; i++ {
 					tag := fmt.Sprintf("test%d", i)
 					tagList = append(tagList, tag)
@@ -79,8 +78,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Populate registry with test tags (no push)", func() {
-				RunOnlyIfNot(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
+				RunOnlyIfNot(runContentDiscoverySetup)
 				tagList = strings.Split(os.Getenv(envVarTagList), ",")
 			})
 		})
@@ -130,9 +129,8 @@ var test03ContentDiscovery = func() {
 
 		g.Context("Teardown", func() {
 			g.Specify("Delete config blob created in tests", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
-				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -142,9 +140,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Delete layer blob created in setup", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
-				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -154,9 +151,8 @@ var test03ContentDiscovery = func() {
 			})
 
 			g.Specify("Delete created manifest & associated tags", func() {
-				RunOnlyIf(runContentDiscoverySetup)
 				SkipIfDisabled(contentDiscovery)
-				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentDiscoverySetup)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/04_management_test.go
+++ b/conformance/04_management_test.go
@@ -18,12 +18,11 @@ var test04ContentManagement = func() {
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test config blob", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-
 				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
 					SetHeader("Content-Length", configBlobContentLength).
 					SetHeader("Content-Type", "application/octet-stream").
@@ -37,8 +36,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("Populate registry with test layer", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -55,8 +54,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("Populate registry with test tag", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				tagToDelete = defaultTagName
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(tagToDelete)).
@@ -70,8 +69,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("Check how many tags there are before anything gets deleted", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/tags/list")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -141,8 +140,8 @@ var test04ContentManagement = func() {
 
 		g.Context("Blob delete", func() {
 			g.Specify("DELETE request to blob URL should yield 202 response", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				// config blob
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
@@ -157,8 +156,8 @@ var test04ContentManagement = func() {
 			})
 
 			g.Specify("GET request to deleted blob URL should yield 404 response", func() {
-				RunOnlyIf(runContentManagementSetup)
 				SkipIfDisabled(contentManagement)
+				RunOnlyIf(runContentManagementSetup)
 				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -15,11 +15,21 @@ This will produce an executable at `conformance.test`.
 
 Next, set environment variables with your registry details:
 ```
+# Registry details
 export OCI_ROOT_URL="https://r.myreg.io"
 export OCI_NAMESPACE="myorg/myrepo"
 export OCI_USERNAME="myuser"
 export OCI_PASSWORD="mypass"
-export OCI_DEBUG="true"
+
+# Which workflows to run
+export OCI_TEST_PULL=1
+export OCI_TEST_PUSH=1
+export OCI_TEST_CONTENT_DISCOVERY=1
+export OCI_TEST_CONTENT_MANAGEMENT=1
+
+# Extra settings
+export OCI_HIDE_SKIPPED_WORKFLOWS=0
+export OCI_DEBUG=0
 ```
 
 Lastly, run the tests:
@@ -156,7 +166,12 @@ docker run --rm \
   -e OCI_NAMESPACE="myorg/myrepo" \
   -e OCI_USERNAME="myuser" \
   -e OCI_PASSWORD="mypass" \
-  -e OCI_DEBUG="true" \
+  -e OCI_TEST_PULL=1 \
+  -e OCI_TEST_PUSH=1 \
+  -e OCI_TEST_CONTENT_DISCOVERY=1 \
+  -e OCI_TEST_CONTENT_MANAGEMENT=1 \
+  -e OCI_HIDE_SKIPPED_WORKFLOWS=0
+  -e OCI_DEBUG=0 \
   conformance:latest
 ```
 
@@ -185,6 +200,12 @@ jobs:
           OCI_NAMESPACE: mytestorg/mytestrepo
           OCI_USERNAME: ${{ secrets.MY_REGISTRY_USERNAME }}
           OCI_PASSWORD: ${{ secrets.MY_REGISTRY_PASSWORD }}
+          OCI_TEST_PULL: 1
+          OCI_TEST_PUSH: 1
+          OCI_TEST_CONTENT_DISCOVERY: 1
+          OCI_TEST_CONTENT_MANAGEMENT: 1
+          OCI_HIDE_SKIPPED_WORKFLOWS: 0
+          OCI_DEBUG: 0
       - run: mkdir -p .out/ && mv {report.html,junit.xml} .out/
         if: always()
       - name: Upload test results zip as build artifact

--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -538,18 +538,23 @@ func (reporter *HTMLReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 //unused by HTML reporter
 func (reporter *HTMLReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
 	varsToCheck := []string{
-		"OCI_ROOT_URL",
-		"OCI_NAMESPACE",
-		"OCI_DEBUG",
-		"OCI_PASSWORD",
-		"OCI_USERNAME",
+		envVarRootURL,
+		envVarNamespace,
+		envVarUsername,
+		envVarPassword,
+		envVarDebug,
+		envVarPull,
 		envVarPush,
 		envVarContentDiscovery,
 		envVarContentManagement,
+		envVarPushEmptyLayer,
 		envVarBlobDigest,
 		envVarManifestDigest,
+		envVarEmptyLayerManifestDigest,
 		envVarTagName,
 		envVarTagList,
+		envVarHideSkippedWorkflows,
+		envVarAuthScope,
 	}
 	for _, v := range varsToCheck {
 		var replacement string

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -9,11 +9,10 @@ import (
 	"os"
 	"strconv"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"github.com/bloodorangeio/reggie"
 	g "github.com/onsi/ginkgo"
 	godigest "github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type (
@@ -40,7 +39,13 @@ const (
 	DENIED
 	UNSUPPORTED
 
-	envTrue                        = "1"
+	envTrue = "1"
+
+	envVarRootURL                  = "OCI_ROOT_URL"
+	envVarNamespace                = "OCI_NAMESPACE"
+	envVarUsername                 = "OCI_USERNAME"
+	envVarPassword                 = "OCI_PASSWORD"
+	envVarDebug                    = "OCI_DEBUG"
 	envVarPull                     = "OCI_TEST_PULL"
 	envVarPush                     = "OCI_TEST_PUSH"
 	envVarContentDiscovery         = "OCI_TEST_CONTENT_DISCOVERY"
@@ -126,12 +131,12 @@ var (
 func init() {
 	var err error
 
-	hostname := os.Getenv("OCI_ROOT_URL")
-	namespace := os.Getenv("OCI_NAMESPACE")
-	username := os.Getenv("OCI_USERNAME")
-	password := os.Getenv("OCI_PASSWORD")
+	hostname := os.Getenv(envVarRootURL)
+	namespace := os.Getenv(envVarNamespace)
+	username := os.Getenv(envVarUsername)
+	password := os.Getenv(envVarPassword)
 	authScope := os.Getenv(envVarAuthScope)
-	debug := os.Getenv("OCI_DEBUG") == "true"
+	debug := os.Getenv(envVarDebug) == envTrue
 
 	for envVar, enableTest := range testMap {
 		if os.Getenv(envVar) == envTrue {


### PR DESCRIPTION
Also includes several minor changes:

- Change debug truthy var to "1" vs "true"
- Add constants for env vars like OCI_ROOT_URL
- Ensure all OCI_ vars are displayed in HTML report
- Update README to reflect new workflow env vars

Resolves #141.
Resolves #140.