### PR TITLE
Disable cookie handling by default

### DIFF
--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -152,6 +152,7 @@ func init() {
 	}
 
 	client.SetLogger(logger)
+	client.SetCookieJar(nil)
 
 	config := imagespec.Image{
 		Architecture: "amd64",


### PR DESCRIPTION
Set the cookie jar to nil is to disable save cookies in api contacting.

Signed-off-by: wang yan <wangyan@vmware.com>