### PR TITLE
Minor changes

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -252,9 +252,13 @@ var test02Push = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			g.Specify("Delete layer blob created in setup", func() {
@@ -263,9 +267,13 @@ var test02Push = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			g.Specify("Delete manifest created in tests", func() {
@@ -274,9 +282,13 @@ var test02Push = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 		})
 	})

--- a/conformance/04_management_test.go
+++ b/conformance/04_management_test.go
@@ -84,7 +84,7 @@ var test04ContentManagement = func() {
 		})
 
 		g.Context("Manifest delete", func() {
-			g.Specify("DELETE request to manifest tag should return 202, unless tag deletion is disallowed (400)", func() {
+			g.Specify("DELETE request to manifest tag should return 202, unless tag deletion is disallowed (400/405)", func() {
 				SkipIfDisabled(contentManagement)
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(tagToDelete))
@@ -92,7 +92,8 @@ var test04ContentManagement = func() {
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(SatisfyAny(
 					Equal(http.StatusBadRequest),
-					Equal(http.StatusAccepted)))
+					Equal(http.StatusAccepted),
+					Equal(http.StatusMethodNotAllowed)))
 				if resp.StatusCode() == http.StatusBadRequest {
 					errorResponses, err := resp.Errors()
 					Expect(err).To(BeNil())

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -39,8 +39,6 @@ const (
 	DENIED
 	UNSUPPORTED
 
-	envTrue = "1"
-
 	envVarRootURL                  = "OCI_ROOT_URL"
 	envVarNamespace                = "OCI_NAMESPACE"
 	envVarUsername                 = "OCI_USERNAME"
@@ -136,10 +134,11 @@ func init() {
 	username := os.Getenv(envVarUsername)
 	password := os.Getenv(envVarPassword)
 	authScope := os.Getenv(envVarAuthScope)
-	debug := os.Getenv(envVarDebug) == envTrue
+
+	debug, _ := strconv.ParseBool(os.Getenv(envVarDebug))
 
 	for envVar, enableTest := range testMap {
-		if os.Getenv(envVar) == envTrue {
+		if varIsTrue, _ := strconv.ParseBool(os.Getenv(envVar)); varIsTrue {
 			testsToRun |= enableTest
 		}
 	}
@@ -286,9 +285,7 @@ func init() {
 		runContentDiscoverySetup = false
 	}
 
-	if os.Getenv(envVarPushEmptyLayer) == envTrue {
-		skipEmptyLayerTest = true
-	}
+	skipEmptyLayerTest, _ = strconv.ParseBool(os.Getenv(envVarPushEmptyLayer))
 
 	reportJUnitFilename = "junit.xml"
 	reportHTMLFilename = "report.html"


### PR DESCRIPTION
- Allow 405 response for deletion in push teardown
- Use strconv.ParseBool to check env var truthiness
- Allow 405 response for tag deletion

Resolves #150. Reolves #145. Resolves #136.