### PR TITLE
Expand allowed status codes

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -71,7 +71,10 @@ var test02Push = func() {
 				Expect(err).To(BeNil())
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					Equal(http.StatusCreated),
+					Equal(http.StatusAccepted),
+				))
 			})
 
 			g.Specify("GET request to blob URL from prior request should yield 200", func() {


### PR DESCRIPTION
POST /v2/\<name\>/blobs/uploads/?digest=\<digest\> should allow for 202 Accepted.
All DELETE calls should allow 405 Method Not Allowed.

This PR resolves the following comment by @jdolitsky on [issue 68](https://github.com/opencontainers/distribution-spec/issues/68#issuecomment-628254410_). Resolving this issue will make several registries go green on the relevant workflows.