### PR TITLE
Allow 405 Method Not Allowed for DELETE requests in teardowns

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -159,9 +159,13 @@ var test01Pull = func() {
 					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 					resp, err := client.Do(req)
 					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300)))
+					Expect(resp.StatusCode()).To(SatisfyAny(
+						SatisfyAll(
+							BeNumerically(">=", 200),
+							BeNumerically("<", 300),
+						),
+						Equal(http.StatusMethodNotAllowed),
+					))
 				})
 			}
 
@@ -171,9 +175,13 @@ var test01Pull = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			g.Specify("Delete layer blob created in setup", func() {
@@ -182,9 +190,13 @@ var test01Pull = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			if !deleteManifestBeforeBlobs {
@@ -194,9 +206,13 @@ var test01Pull = func() {
 					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 					resp, err := client.Do(req)
 					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300)))
+					Expect(resp.StatusCode()).To(SatisfyAny(
+						SatisfyAll(
+							BeNumerically(">=", 200),
+							BeNumerically("<", 300),
+						),
+						Equal(http.StatusMethodNotAllowed),
+					))
 				})
 			}
 		})

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -135,9 +135,13 @@ var test03ContentDiscovery = func() {
 					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 					resp, err := client.Do(req)
 					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300)))
+					Expect(resp.StatusCode()).To(SatisfyAny(
+						SatisfyAll(
+							BeNumerically(">=", 200),
+							BeNumerically("<", 300),
+						),
+						Equal(http.StatusMethodNotAllowed),
+					))
 				})
 			}
 
@@ -147,9 +151,13 @@ var test03ContentDiscovery = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			g.Specify("Delete layer blob created in setup", func() {
@@ -158,9 +166,13 @@ var test03ContentDiscovery = func() {
 				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					SatisfyAll(
+						BeNumerically(">=", 200),
+						BeNumerically("<", 300),
+					),
+					Equal(http.StatusMethodNotAllowed),
+				))
 			})
 
 			if !deleteManifestBeforeBlobs {
@@ -170,9 +182,13 @@ var test03ContentDiscovery = func() {
 					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifestDigest))
 					resp, err := client.Do(req)
 					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300)))
+					Expect(resp.StatusCode()).To(SatisfyAny(
+						SatisfyAll(
+							BeNumerically(">=", 200),
+							BeNumerically("<", 300),
+						),
+						Equal(http.StatusMethodNotAllowed),
+					))
 				})
 			}
 		})


### PR DESCRIPTION
Fixes: https://github.com/opencontainers/distribution-spec/issues/179

Allows `405 Method Not Allowed` HTTP Response Status in teardown methods in conformance tests