### PR TITLE
spec: add missing TOOMANYREQUESTS (429) error-code

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -469,7 +469,8 @@ The `code` field MUST be one of the following:
 | code-12 | `TAG_INVALID`           | manifest tag did not match URI                 |
 | code-13 | `UNAUTHORIZED`          | authentication required                        |
 | code-14 | `DENIED`                | requested access to the resource is denied     |
-| code-15 | `UNSUPPORTED`           | the operation is unsupported                  |
+| code-15 | `UNSUPPORTED`           | the operation is unsupported                   |
+| code-16 | `TOOMANYREQUESTS`       | too many requests                              |
 
 ### Appendix
 


### PR DESCRIPTION
The `TOOMANYREQUESTS` error code was added in docker/distribution#1693, and added to the documentation in docker/distribution#1833.

While it's documented in various examples, it never made it to the list of allowed error-codes.

This patch is fixing that omission and adding it to the list of valid error-codes that can be returned by registries
