### PR TITLE
Describe single-request monolithic upload behavior

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -197,34 +197,8 @@ There are two ways to push blobs: chunked or monolithic.
 ##### Pushing a blob monolithically
 
 There are two ways to push a blob monolithically:
-1. A single `POST` request
-2. A `POST` request followed by a `PUT` request
-
----
-
-To push a blob monolithically by using a single POST request, perform a `POST` request to a URL in the following form, and with the following headers and body:
-
-`/v2/<name>/blobs/uploads/?digest=<digest>` <sup>[end-4b](#endpoints)</sup>
-```
-Content-Length: <length>
-Content-Type: application/octet-stream
-```
-```
-<upload byte stream>
-```
-
-Here, `<name>` is the repository's namespace, `<digest>` is the blob's digest, and `<length>` is the size (in bytes) of the blob.
-
-The `Content-Length` header MUST match the blob's actual content length. Likewise, the `<digest>` MUST match the blob's digest.
-
-Successful completion of the request MUST return either a `201 Created` or a `202 Accepted`, and MUST include the following header:
-
-```
-Location: <blob-location>
-```
-
-Here, `<blob-location>` is a pullable blob URL. This location does not necessarily have to be served by your register, for example, in the case of a signed URL from
-some cloud storage provider that your registry generates.
+1. A `POST` request followed by a `PUT` request
+2. A single `POST` request
 
 ---
 
@@ -269,6 +243,33 @@ Location: <blob-location>
 ```
 
 With `<blob-location>` being a pullable blob URL.
+
+---
+
+To push a blob monolithically by using a single POST request, perform a `POST` request to a URL in the following form, and with the following headers and body:
+
+`/v2/<name>/blobs/uploads/?digest=<digest>` <sup>[end-4b](#endpoints)</sup>
+```
+Content-Length: <length>
+Content-Type: application/octet-stream
+```
+```
+<upload byte stream>
+```
+
+Here, `<name>` is the repository's namespace, `<digest>` is the blob's digest, and `<length>` is the size (in bytes) of the blob.
+
+The `Content-Length` header MUST match the blob's actual content length. Likewise, the `<digest>` MUST match the blob's digest.
+
+Successful completion of the request MUST return either a `201 Created` or a `202 Accepted`, and MUST include the following header:
+
+```
+Location: <blob-location>
+```
+
+Here, `<blob-location>` is a pullable blob URL. This location does not necessarily have to be served by your register, for example, in the case of a signed URL from
+some cloud storage provider that your registry generates.
+
 
 ##### Pushing a blob in chunks
 

--- a/spec.md
+++ b/spec.md
@@ -202,6 +202,8 @@ There are two ways to push a blob monolithically:
 
 ---
 
+###### POST then PUT
+
 To push a blob monolithically by using a POST request followed by a PUT request, there are two steps:
 1. Obtain a session id (upload URL)
 2. Upload the blob to said URL
@@ -246,6 +248,10 @@ With `<blob-location>` being a pullable blob URL.
 
 ---
 
+###### Single POST
+
+Registries MAY support pushing blobs using a single POST request.
+
 To push a blob monolithically by using a single POST request, perform a `POST` request to a URL in the following form, and with the following headers and body:
 
 `/v2/<name>/blobs/uploads/?digest=<digest>` <sup>[end-4b](#endpoints)</sup>
@@ -261,7 +267,9 @@ Here, `<name>` is the repository's namespace, `<digest>` is the blob's digest, a
 
 The `Content-Length` header MUST match the blob's actual content length. Likewise, the `<digest>` MUST match the blob's digest.
 
-Successful completion of the request MUST return either a `201 Created` or a `202 Accepted`, and MUST include the following header:
+Registries that do not support single request monolithic uploads SHOULD return a `202 Accepted` status code and `Location` header and clients SHOULD proceed with a subsequent PUT request, as described by the [POST then PUT upload method](#post-then-put).
+
+Successful completion of the request MUST return a `201 Created` and MUST include the following header:
 
 ```
 Location: <blob-location>


### PR DESCRIPTION
This addresses the uncontroversial part of https://github.com/opencontainers/distribution-spec/issues/234 by describing how clients should interpret the response codes from registries who do not support single request monolithic uploads.

I am happy to follow up with a deprecation doc, but the existing language from https://github.com/opencontainers/distribution-spec/pull/221 is actually pretty reasonable and expresses some of what I had intended to convey by deprecating this.

The PR diff is not great because I flipped the order in which monolithic blob uploads are introduced, but I've split that into a separate commit to make it easier to review.