### PR TITLE
Fix trivial typo in TOC of spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -5,7 +5,7 @@
 - [Overview](#overview)
 	- [Introduction](#introduction)
 	- [Historical Context](#historical-context)
-	- [Definitions](#defintions)
+	- [Definitions](#definitions)
 - [Use Cases](#use-cases)
 - [Notational Conventions](#notational-conventions)
 - [Conformance](#conformance)


### PR DESCRIPTION
The `#defintions` anchor isn't found, so clicking the link goes nowhere.