### PR TITLE
Fix the generation of release PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 else
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 	mkdir -p $(OUTPUT_DIRNAME)/ && \
-	$(PANDOC) -f gfm -t latex --pdf-engine=xelatex -V geometry:margin=0.4in,bottom=0.8in -V block-headings -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
+	$(PANDOC) -f gfm -t latex --pdf-engine=xelatex -V geometry:margin=0.5in,bottom=0.8in -V block-headings -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
 	ls -sh $(realpath $@)
 
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).html: header.html $(DOC_FILES) $(FIGURE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCILINT	?= $(shell command -v golangcli-lint 2>/dev/null)
 OUTPUT_DIRNAME	?= output/
 DOC_FILENAME	?= oci-distribution-spec
 
-PANDOC_CONTAINER ?= ghcr.io/opencontainers/pandoc:2.9.2.1-8.fc33.x86_64@sha256:f589b9ed61cfbe2abdc0cc0f226507601acbae844f5bd8725b908dc493596dc1
+PANDOC_CONTAINER ?= ghcr.io/opencontainers/pandoc:2.9.2.1-8.fc33.x86_64@sha256:5d81ff930a043295a557be8b003ece2a33d14e91b28c50d368413b83372f8d28
 ifeq "$(strip $(PANDOC))" ''
 	ifneq "$(strip $(DOCKER))" ''
 		PANDOC = $(DOCKER) run \
@@ -24,7 +24,7 @@ ifeq "$(strip $(PANDOC))" ''
 	endif
 endif
 
-GOLANGCILINT_CONTAINER ?= docker.io/golangci/golangci-lint:v1.38.0
+GOLANGCILINT_CONTAINER ?= ghcr.io/opencontainers/golangci-lint:v1.39.0@sha256:7bc0728c3034ee198e6ed439ad73d1512809a65aaccec2b2e2297c08582e5afd
 ifeq "$(strip $(GOLANGCILINT))" ''
 	ifneq "$(strip $(DOCKER))" ''
 		GOLANGCILINT = $(DOCKER) run \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCILINT	?= $(shell command -v golangcli-lint 2>/dev/null)
 OUTPUT_DIRNAME	?= output/
 DOC_FILENAME	?= oci-distribution-spec
 
-PANDOC_CONTAINER ?= ghcr.io/jdolitsky/pandoc:aab258d@sha256:4772df87734a8c7cf1f4c8407a8b452ab3c9b250b425f27b657f9ca01d9a696b
+PANDOC_CONTAINER ?= ghcr.io/opencontainers/pandoc:2.9.2.1-8.fc33.x86_64@sha256:f589b9ed61cfbe2abdc0cc0f226507601acbae844f5bd8725b908dc493596dc1
 ifeq "$(strip $(PANDOC))" ''
 	ifneq "$(strip $(DOCKER))" ''
 		PANDOC = $(DOCKER) run \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCILINT	?= $(shell command -v golangcli-lint 2>/dev/null)
 OUTPUT_DIRNAME	?= output/
 DOC_FILENAME	?= oci-distribution-spec
 
-PANDOC_CONTAINER ?= docker.io/vbatts/pandoc:1.19.1-3.fc27.x86_64
+PANDOC_CONTAINER ?= ghcr.io/jdolitsky/pandoc:aab258d@sha256:4772df87734a8c7cf1f4c8407a8b452ab3c9b250b425f27b657f9ca01d9a696b
 ifeq "$(strip $(PANDOC))" ''
 	ifneq "$(strip $(DOCKER))" ''
 		PANDOC = $(DOCKER) run \
@@ -65,17 +65,18 @@ $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 else
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 	mkdir -p $(OUTPUT_DIRNAME)/ && \
-	$(PANDOC) -f markdown_github -t latex --latex-engine=xelatex -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
+	$(PANDOC) -f gfm -t latex --pdf-engine=xelatex -V geometry:margin=0.4in,bottom=0.8in -V block-headings -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
 	ls -sh $(realpath $@)
 
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).html: header.html $(DOC_FILES) $(FIGURE_FILES)
 	mkdir -p $(OUTPUT_DIRNAME)/ && \
 	cp -ap img/ $(shell pwd)/$(OUTPUT_DIRNAME)/&& \
-	$(PANDOC) -f markdown_github -t html5 -H $(PANDOC_SRC)header.html --standalone -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
+	$(PANDOC) -f gfm -t html5 -H $(PANDOC_SRC)header.html --standalone -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
 	ls -sh $(realpath $@)
 endif
 
 header.html: .tool/genheader.go specs-go/version.go
+	go mod init && \
 	go run .tool/genheader.go > $@
 
 install.tools: .install.gitvalidation

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,4 @@ inputs: {}
 outputs: {}
 runs:
   using: docker
-  # TODO: change to "docker://ghcr.io/opencontainers/distribution-spec/conformance:<TAG>"
-  image: conformance/Dockerfile
+  image: "docker://ghcr.io/opencontainers/distribution-spec/conformance:v1.0.0-rc2@sha256:2f0ced454ce31793cc69d48a05233ea76f2ebe791936d053342b66388a6de260"

--- a/detail.md
+++ b/detail.md
@@ -1,6 +1,6 @@
 ## Detail
 
-> **Note**: This section is still under construction.
+> **Note**: This section is still under construction. Information may be out-of-date or not yet implemented.
 > For the purposes of implementation, if any details below differ from the described request flows above, the section below SHOULD be corrected.
 > When they match, this note SHOULD be removed.
 

--- a/spec.md
+++ b/spec.md
@@ -356,10 +356,10 @@ Here, `<blob-location>` is a pullable blob URL.
 If a necessary blob exists already in another repository, it can be mounted into a different repository via a `POST`
 request in the following format:
 
-`/v2/<name>/blobs/uploads/?mount=<digest>&from=<repository_name>`  <sup>[end-11](#endpoints)</sup>.
+`/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_name>`  <sup>[end-11](#endpoints)</sup>.
 
 In this case, `<name>` is the namespace to which the blob will be mounted. `<digest>` is the digest of the blob to mount,
-and `<repository_name>` is the namespace from which the blob should be mounted. This step is usually taken in place of the
+and `<other_name>` is the namespace from which the blob should be mounted. This step is usually taken in place of the
 previously-described `POST` request to `/v2/<name>/blobs/uploads/` <sup>[end-4a](#endpoints)</sup> (which is used to initiate an
 upload session).
 
@@ -494,20 +494,20 @@ of this specification.
 #### Endpoints
 
 | ID     | Method         | API Endpoint                                                      | Success     | Failure           |
-| ------ | -------------- | ----------------------------------------------------------------- | ----------- | ----------------- |
-| end-1  | `GET`          | `/v2/`                                                            | `200`       | `404`/`401`       |
-| end-2  | `GET` / `HEAD` | `/v2/<name>/blobs/<digest>`                                       | `200`       | `404`             |
-| end-3  | `GET` / `HEAD` | `/v2/<name>/manifests/<reference>`                                | `200`       | `404`             |
-| end-4a | `POST`         | `/v2/<name>/blobs/uploads/`                                       | `202`       | `404`             |
-| end-4b | `POST`         | `/v2/<name>/blobs/uploads/?digest=<digest>`                       | `201`/`202` | `404`/`400`       |
-| end-5  | `PATCH`        | `/v2/<name>/blobs/uploads/<reference>`                            | `202`       | `404`/`416`       |
-| end-6  | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`            | `201`       | `404`/`400`       |
-| end-7  | `PUT`          | `/v2/<name>/manifests/<reference>`                                | `201`       | `404`             |
-| end-8a | `GET`          | `/v2/<name>/tags/list`                                            | `200`       | `404`             |
-| end-8b | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`                 | `200`       | `404`             |
-| end-9  | `DELETE`       | `/v2/<name>/manifests/<reference>`                                | `202`       | `404`/`400`/`405` |
-| end-10 | `DELETE`       | `/v2/<name>/blobs/<digest>`                                       | `202`       | `404`/`405`       |
-| end-11 | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_namespace>` | `201`       | `404`             |
+| ------ | -------------- | ------------------------------------------------------------ | ----------- | ----------------- |
+| end-1  | `GET`          | `/v2/`                                                       | `200`       | `404`/`401`       |
+| end-2  | `GET` / `HEAD` | `/v2/<name>/blobs/<digest>`                                  | `200`       | `404`             |
+| end-3  | `GET` / `HEAD` | `/v2/<name>/manifests/<reference>`                           | `200`       | `404`             |
+| end-4a | `POST`         | `/v2/<name>/blobs/uploads/`                                  | `202`       | `404`             |
+| end-4b | `POST`         | `/v2/<name>/blobs/uploads/?digest=<digest>`                  | `201`/`202` | `404`/`400`       |
+| end-5  | `PATCH`        | `/v2/<name>/blobs/uploads/<reference>`                       | `202`       | `404`/`416`       |
+| end-6  | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`       | `201`       | `404`/`400`       |
+| end-7  | `PUT`          | `/v2/<name>/manifests/<reference>`                           | `201`       | `404`             |
+| end-8a | `GET`          | `/v2/<name>/tags/list`                                       | `200`       | `404`             |
+| end-8b | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`            | `200`       | `404`             |
+| end-9  | `DELETE`       | `/v2/<name>/manifests/<reference>`                           | `202`       | `404`/`400`/`405` |
+| end-10 | `DELETE`       | `/v2/<name>/blobs/<digest>`                                  | `202`       | `404`/`405`       |
+| end-11 | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_name>` | `201`       | `404`             |
 
 #### Error Codes
 

--- a/spec.md
+++ b/spec.md
@@ -69,8 +69,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Use Cases
 
-TODO: more detail on workflows related
-
 ### Artifact Verification
 
 A container engine would like to run verified image named "library/ubuntu", with the tag "latest".
@@ -354,6 +352,7 @@ Here, `<blob-location>` is a pullable blob URL.
 
 
 ##### Mounting a blob from another repository
+
 If a necessary blob exists already in another repository, it can be mounted into a different repository via a `POST`
 request in the following format:
 
@@ -449,10 +448,12 @@ results, but up to `<int>` tags *after* `<tagname>` will be returned. The tags M
 When using the `last` query parameter, the `n` parameter is OPTIONAL.
 
 #### Content Management
+
 Content management refers to the deletion of blobs, tags, and manifests. Registries MAY implement deletion or they MAY
 disable it. Similarly, a registry MAY implement tag deletion, while others MAY allow deletion only by manifest.
 
 ##### Deleting tags
+
 `<name>` is the namespace of the repository, and `<tag>` is the name of the tag to be deleted. Upon success, the registry
 MUST respond with a `202 Accepted` code. If tag deletion is disabled, the registry MUST respond with either a
 `400 Bad Request` or a `405 Method Not Allowed`.
@@ -461,6 +462,7 @@ To delete a tag, perform a `DELETE` request to a path in the following format:
 `/v2/<name>/manifests/<tag>` <sup>[end-9](#endpoints)</sup>
 
 ##### Deleting Manifests
+
 To delete a manifest, perform a `DELETE` request to a path in the following format:
 `/v2/<name>/manifests/<digest>` <sup>[end-9](#endpoints)</sup>
 
@@ -468,6 +470,7 @@ To delete a manifest, perform a `DELETE` request to a path in the following form
 MUST respond with a `202 Accepted` code. If the repository does not exist, the response MUST return `404 Not Found`.
 
 ##### Deleting Blobs
+
 To delete a blob, perform a `DELETE` request to a path in the following format:
 `/v2/<name>/blobs/<digest>` <sup>[end-10](#endpoints)</sup>
 
@@ -475,9 +478,11 @@ To delete a blob, perform a `DELETE` request to a path in the following format:
 registry MUST respond with code `202 Accepted`. If the blob is not found, a `404 Not Found` code MUST be returned.
 
 ### API
+
 The API operates over HTTP. Below is a summary of the endpoints used by the API.
 
 #### Determining Support
+
 To check whether or not the registry implements this specification, perform a `GET` request to the following endpoint:
 `/v2/` <sup>[end-1](#endpoints)</sup>.
 
@@ -488,21 +493,21 @@ of this specification.
 
 #### Endpoints
 
-| ID     | Method         | API endpoint                                                      | Accepted Successful Response Codes | Accepted Failure Response Codes |
-| ------ | -------------- | ----------------------------------------------------------------- | ---------------------------------- | ------------------------------- |
-| end-1  | `GET`          | `/v2/`                                                            | `200`                              | `404`/`401`                     |
-| end-2  | `GET` / `HEAD` | `/v2/<name>/blobs/<digest>`                                       | `200`                              | `404`                           |
-| end-3  | `GET` / `HEAD` | `/v2/<name>/manifests/<reference>`                                | `200`                              | `404`                           |
-| end-4a | `POST`         | `/v2/<name>/blobs/uploads/`                                       | `202`                              | `404`                           |
-| end-4b | `POST`         | `/v2/<name>/blobs/uploads/?digest=<digest>`                       | `201`/`202`                        | `404`/`400`                     |
-| end-5  | `PATCH`        | `/v2/<name>/blobs/uploads/<reference>`                            | `202`                              | `404`/`416`                     |
-| end-6  | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`            | `201`                              | `404`/`400`                     |
-| end-7  | `PUT`          | `/v2/<name>/manifests/<reference>`                                | `201`                              | `404`                           |
-| end-8a | `GET`          | `/v2/<name>/tags/list`                                            | `200`                              | `404`                           |
-| end-8b | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`                 | `200`                              | `404`                           |
-| end-9  | `DELETE`       | `/v2/<name>/manifests/<reference>`                                | `202`                              | `404`/`400`/`405`               |
-| end-10 | `DELETE`       | `/v2/<name>/blobs/<digest>`                                       | `202`                              | `404`/`405`                     |
-| end-11 | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_namespace>` | `201`                              | `404`                           |
+| ID     | Method         | API Endpoint                                                      | Success     | Failure           |
+| ------ | -------------- | ----------------------------------------------------------------- | ----------- | ----------------- |
+| end-1  | `GET`          | `/v2/`                                                            | `200`       | `404`/`401`       |
+| end-2  | `GET` / `HEAD` | `/v2/<name>/blobs/<digest>`                                       | `200`       | `404`             |
+| end-3  | `GET` / `HEAD` | `/v2/<name>/manifests/<reference>`                                | `200`       | `404`             |
+| end-4a | `POST`         | `/v2/<name>/blobs/uploads/`                                       | `202`       | `404`             |
+| end-4b | `POST`         | `/v2/<name>/blobs/uploads/?digest=<digest>`                       | `201`/`202` | `404`/`400`       |
+| end-5  | `PATCH`        | `/v2/<name>/blobs/uploads/<reference>`                            | `202`       | `404`/`416`       |
+| end-6  | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`            | `201`       | `404`/`400`       |
+| end-7  | `PUT`          | `/v2/<name>/manifests/<reference>`                                | `201`       | `404`             |
+| end-8a | `GET`          | `/v2/<name>/tags/list`                                            | `200`       | `404`             |
+| end-8b | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`                 | `200`       | `404`             |
+| end-9  | `DELETE`       | `/v2/<name>/manifests/<reference>`                                | `202`       | `404`/`400`/`405` |
+| end-10 | `DELETE`       | `/v2/<name>/blobs/<digest>`                                       | `202`       | `404`/`405`       |
+| end-11 | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_namespace>` | `201`       | `404`             |
 
 #### Error Codes
 
@@ -552,7 +557,7 @@ The following is a list of documents referenced in this spec:
 | ID     | Title | Description |
 | ------ | ----- | ----------- |
 | apdx-1 | [Docker Registry HTTP API V2](https://github.com/docker/distribution/blob/5cb406d511b7b9163bff9b6439072e4892e5ae3b/docs/spec/api.md) | The original document upon which this spec was based |
-| apdx-1 | [Details](./detail.md) | Historical document describing original API endpoints and requests in detail (warning: some of this information may be out-of-date or not yet implemented) |
+| apdx-1 | [Details](./detail.md) | Historical document describing original API endpoints and requests in detail |
 | apdx-2 | [OCI Image Spec - manifests](https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md) | Description of manifests, defined by the OCI Image Spec |
 | apdx-3 | [OCI Image Spec - digests](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests) | Description of digests, defined by the OCI Image Spec |
 | apdx-4 | [OCI Image Spec - config](https://github.com/opencontainers/image-spec/blob/v1.0.1/config.md) | Description of configs, defined by the OCI Image Spec |


### PR DESCRIPTION
Also:

- Fix formatting for pandoc markdown to pdf
- Remove undone TODO in spec.md
- Use released container image for github action

Resolves #258 

@vbatts - replaced pandoc image with an updated one published under my github account. Here are the changes if you want to publish to yours (hub/quay/github) and we can switch it back: https://github.com/vbatts/container-images/pull/2