### PR TITLE
Add @jonjohnsonjr as a dist-spec maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,3 +4,4 @@ Josh Dolitsky <josh@bloodorange.io> (@jdolitsky)
 Mike Brown <brownwm@us.ibm.com> (@mikebrow)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)
 Vincent Batts <vbatts@hashbangbash.com> (@vbatts)
+John Johnson <jonjohnson@google.com> <@jonjohnsonjr>


### PR DESCRIPTION
@jonjohnsonjr would like to become an OCI distribution spec maintainer

https://github.com/opencontainers/tob/issues/95#issuecomment-811522802

We will have the existing maintainers vote via this PR with a LGTM / +1

- [ ] Derek McGowan (@dmcgowan)
- [ ] Jimmy Zelinskie (@jzelinskie)
- [ ] Josh Dolitsky (@jdolitsky)
- [ ] Mike Brown  (@mikebrow)
- [x] Stephen Day (@stevvooe)
- [ ] Vincent Batts (@vbatts)

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>