### PR TITLE
Add Jon Johnson as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dmcgowan @jzelinskie @jdolitsky @mikebrow @stevvooe @vbatts
+* @dmcgowan @jzelinskie @jonjohnsonjr @jdolitsky @mikebrow @stevvooe @vbatts

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,6 @@
 Derek McGowan <derek@mcg.dev> (@dmcgowan)
 Jimmy Zelinskie <jimmy@zelinskie.com> (@jzelinskie)
+Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
 Josh Dolitsky <josh@bloodorange.io> (@jdolitsky)
 Mike Brown <brownwm@us.ibm.com> (@mikebrow)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)


### PR DESCRIPTION
Jon Johnson has been helping out with the distribution spec work for some time and has deep knowledge of the protocol and history. As I stated during the audit, we should evaluate each candidate individually. Jon was proposed as a candidate before the audit so this vote is a bit overdue.

Requires 4 maintainer LGTM to reach 2/3 majority
- [x] Derek McGowan (@dmcgowan)
- [x] Jimmy Zelinskie (@jzelinskie)
- [x] Josh Dolitsky (@jdolitsky)
- [x] Mike Brown  (@mikebrow)
- [x] Stephen Day (@stevvooe)
- [ ] Vincent Batts (@vbatts)
