### PR TITLE
Add test for automatic cross mounting behaviour

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -238,6 +238,34 @@ var test02Push = func() {
 				loc := lastResponse.GetRelativeLocation()
 				Expect(loc).To(ContainSubstring("/blobs/uploads/"))
 			})
+
+			g.Specify("Cross-mounting without from, and automatic content discovery enabled should return a 201", func() {
+				SkipIfDisabled(push)
+				RunOnlyIf(runAutomaticCrossmountTest)
+				RunOnlyIf(lastResponse.StatusCode() == http.StatusCreated)
+				RunOnlyIf(automaticCrossmountEnabled)
+
+				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
+					reggie.WithName(crossmountNamespace)).
+					SetQueryParam("mount", testBlobADigest)
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			})
+
+			g.Specify("Cross-mounting without from, and automatic content discovery disabled should return a 202", func() {
+				SkipIfDisabled(push)
+				RunOnlyIf(runAutomaticCrossmountTest)
+				RunOnlyIf(lastResponse.StatusCode() == http.StatusCreated)
+				RunOnlyIfNot(automaticCrossmountEnabled)
+
+				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
+					reggie.WithName(crossmountNamespace)).
+					SetQueryParam("mount", testBlobADigest)
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
+			})
 		})
 
 		g.Context("Manifest Upload", func() {

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -115,6 +115,19 @@ the environment:
 OCI_CROSSMOUNT_NAMESPACE="myorg/other"
 ```
 
+If you want to test the behaviour of automatic content discovery, you should set the `OCI_AUTOMATIC_CROSSMOUNT` variable.
+
+```
+# Do not test automatic cross mounting
+unset OCI_AUTOMATIC_CROSSMOUNT
+
+# Test that automatic cross mounting is working as expected
+OCI_AUTOMATIC_CROSSMOUNT=1
+
+# Test that automatic cross mounting is disabled
+OCI_AUTOMATIC_CROSSMOUNT=0
+```
+
 ##### Content Discovery
 
 The Content Discovery tests validate that the contents of a registry can be discovered.

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -71,6 +71,7 @@ const (
 	envVarAuthScope                 = "OCI_AUTH_SCOPE"
 	envVarDeleteManifestBeforeBlobs = "OCI_DELETE_MANIFEST_BEFORE_BLOBS"
 	envVarCrossmountNamespace       = "OCI_CROSSMOUNT_NAMESPACE"
+	envVarAutomaticCrossmount       = "OCI_AUTOMATIC_CROSSMOUNT"
 
 	emptyLayerTestTag = "emptylayer"
 	testTagName       = "tagtest0"
@@ -97,41 +98,43 @@ var (
 		envVarContentManagement: contentManagement,
 	}
 
-	testBlobA                 []byte
-	testBlobALength           string
-	testBlobADigest           string
-	testBlobB                 []byte
-	testBlobBDigest           string
-	testBlobBChunk1           []byte
-	testBlobBChunk1Length     string
-	testBlobBChunk2           []byte
-	testBlobBChunk2Length     string
-	testBlobBChunk1Range      string
-	testBlobBChunk2Range      string
-	client                    *reggie.Client
-	crossmountNamespace       string
-	dummyDigest               string
-	errorCodes                []string
-	invalidManifestContent    []byte
-	layerBlobData             []byte
-	layerBlobDigest           string
-	layerBlobContentLength    string
-	emptyLayerManifestContent []byte
-	nonexistentManifest       string
-	reportJUnitFilename       string
-	reportHTMLFilename        string
-	httpWriter                *httpDebugWriter
-	testsToRun                int
-	suiteDescription          string
-	runPullSetup              bool
-	runPushSetup              bool
-	runContentDiscoverySetup  bool
-	runContentManagementSetup bool
-	skipEmptyLayerTest        bool
-	deleteManifestBeforeBlobs bool
-	configs                   []TestBlob
-	manifests                 []TestBlob
-	Version                   = "unknown"
+	testBlobA                  []byte
+	testBlobALength            string
+	testBlobADigest            string
+	testBlobB                  []byte
+	testBlobBDigest            string
+	testBlobBChunk1            []byte
+	testBlobBChunk1Length      string
+	testBlobBChunk2            []byte
+	testBlobBChunk2Length      string
+	testBlobBChunk1Range       string
+	testBlobBChunk2Range       string
+	client                     *reggie.Client
+	crossmountNamespace        string
+	dummyDigest                string
+	errorCodes                 []string
+	invalidManifestContent     []byte
+	layerBlobData              []byte
+	layerBlobDigest            string
+	layerBlobContentLength     string
+	emptyLayerManifestContent  []byte
+	nonexistentManifest        string
+	reportJUnitFilename        string
+	reportHTMLFilename         string
+	httpWriter                 *httpDebugWriter
+	testsToRun                 int
+	suiteDescription           string
+	runPullSetup               bool
+	runPushSetup               bool
+	runContentDiscoverySetup   bool
+	runContentManagementSetup  bool
+	skipEmptyLayerTest         bool
+	deleteManifestBeforeBlobs  bool
+	runAutomaticCrossmountTest bool
+	automaticCrossmountEnabled bool
+	configs                    []TestBlob
+	manifests                  []TestBlob
+	Version                    = "unknown"
 )
 
 func init() {
@@ -320,6 +323,9 @@ func init() {
 
 	skipEmptyLayerTest, _ = strconv.ParseBool(os.Getenv(envVarPushEmptyLayer))
 	deleteManifestBeforeBlobs, _ = strconv.ParseBool(os.Getenv(envVarDeleteManifestBeforeBlobs))
+	automaticCrossmountVal := ""
+	automaticCrossmountVal, runAutomaticCrossmountTest = os.LookupEnv(envVarAutomaticCrossmount)
+	automaticCrossmountEnabled, _ = strconv.ParseBool(automaticCrossmountVal)
 
 	reportJUnitFilename = "junit.xml"
 	reportHTMLFilename = "report.html"


### PR DESCRIPTION
This adds conformance tests for automatic cross mounting. Usually, the test
should not run as it can give a false positive. The OCI_AUTOMATIC_CROSSMOUNT
must be set based on how the registry is expected to be configured.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>