### PR TITLE
Conformance tests: delete emptylayer manifest too

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -346,8 +346,8 @@ var test02Push = func() {
 			deleteManifests := func() {
 				deleteManifest(client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>",
 					reggie.WithDigest(manifests[1].Digest)))
-				deleteManifest(client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>",
-					reggie.WithReference(emptyLayerTestTag)))
+				deleteManifest(client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>",
+					reggie.WithDigest(emptyLayerManifestDigest)))
 			}
 
 			if deleteManifestBeforeBlobs {

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -118,6 +118,7 @@ var (
 	layerBlobDigest            string
 	layerBlobContentLength     string
 	emptyLayerManifestContent  []byte
+	emptyLayerManifestDigest   string
 	nonexistentManifest        string
 	reportJUnitFilename        string
 	reportHTMLFilename         string
@@ -267,6 +268,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	emptyLayerManifestDigest = godigest.FromBytes(emptyLayerManifestContent).String()
 
 	nonexistentManifest = ".INVALID_MANIFEST_NAME"
 	invalidManifestContent = []byte("blablabla")


### PR DESCRIPTION
Otherwise the [`Delete config blob created in tests` step](https://github.com/opencontainers/distribution-spec/blob/e0fa2c947754d54c2bcff13918716f5ba16515b3/conformance/02_push_test.go#L357) will fail (even when using `OCI_DELETE_MANIFEST_BEFORE_BLOBS=1`), because the configuration blob that it deletes is also referenced by the emptylayer manifest:

https://github.com/opencontainers/distribution-spec/blob/7be5e8534d10ebdb6d1631a6ecc1beaa5b622f65/conformance/setup.go#L256-L263