### PR TITLE
Add handling of unknown fields to conformance tests

### DIFF
--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.2
 )
 
 require (

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -42,8 +42,6 @@ github.com/opencontainers/distribution-spec v1.0.0-rc0.0.20200108182153-219f20cb
 github.com/opencontainers/distribution-spec v1.0.0-rc0.0.20200108182153-219f20cbcfa1/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
-github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/conformance/image.go
+++ b/conformance/image.go
@@ -1,0 +1,70 @@
+package conformance
+
+import (
+	digest "github.com/opencontainers/go-digest"
+)
+
+// These types are copied from github.com/opencontainers/image-spec/specs-go/v1
+// Modifications have been made to remove fields that aren't used in these
+// conformance tests, and to add new unspecified fields, to test registry
+// conformance in handling unknown fields.
+
+// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
+type Manifest struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+
+	// Config references a configuration object for a container, by digest.
+	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
+	Config Descriptor `json:"config"`
+
+	// Layers is an indexed list of layers referenced by the manifest.
+	Layers []Descriptor `json:"layers"`
+}
+
+// Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// NewUnspecifiedField is not covered by image-spec.
+	// Registry implementations should still successfully store and serve
+	// manifests containing this data.
+	NewUnspecifiedField []byte `json:"newUnspecifiedField"`
+}
+
+// RootFS describes a layer content addresses
+type RootFS struct {
+	// Type is the type of the rootfs.
+	Type string `json:"type"`
+
+	// DiffIDs is an array of layer content hashes (DiffIDs), in order from bottom-most to top-most.
+	DiffIDs []digest.Digest `json:"diff_ids"`
+}
+
+// Image is the JSON structure which describes some basic information about the image.
+// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
+type Image struct {
+	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
+	Author string `json:"author,omitempty"`
+
+	// Architecture is the CPU architecture which the binaries in this image are built to run on.
+	Architecture string `json:"architecture"`
+
+	// Variant is the variant of the specified CPU architecture which image binaries are intended to run on.
+	Variant string `json:"variant,omitempty"`
+
+	// OS is the name of the operating system which the image is built to run on.
+	OS string `json:"os"`
+
+	// RootFS references the layer content addresses used by the image.
+	RootFS RootFS `json:"rootfs"`
+}

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	g "github.com/onsi/ginkgo"
 	godigest "github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type (
@@ -179,10 +178,10 @@ func init() {
 		// in order to get a unique blob digest, we create a new author
 		// field for the config on each run.
 		randomAuthor := randomString(16)
-		config := imagespec.Image{
+		config := Image{
 			Architecture: "amd64",
 			OS:           "linux",
-			RootFS: imagespec.RootFS{
+			RootFS: RootFS{
 				Type:    "layers",
 				DiffIDs: []godigest.Digest{},
 			},
@@ -216,7 +215,7 @@ func init() {
 	layerBlobDigest = layerBlobDigestRaw.String()
 	layerBlobContentLength = fmt.Sprintf("%d", len(layerBlobData))
 
-	layers := []imagespec.Descriptor{{
+	layers := []Descriptor{{
 		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 		Size:      int64(len(layerBlobData)),
 		Digest:    layerBlobDigestRaw,
@@ -224,11 +223,12 @@ func init() {
 
 	// create a unique manifest for each workflow category
 	for i := 0; i < 4; i++ {
-		manifest := imagespec.Manifest{
-			Config: imagespec.Descriptor{
-				MediaType: "application/vnd.oci.image.config.v1+json",
-				Digest:    godigest.Digest(configs[i].Digest),
-				Size:      int64(len(configs[i].Content)),
+		manifest := Manifest{
+			Config: Descriptor{
+				MediaType:           "application/vnd.oci.image.config.v1+json",
+				Digest:              godigest.Digest(configs[i].Digest),
+				Size:                int64(len(configs[i].Content)),
+				NewUnspecifiedField: configs[i].Content,
 			},
 			Layers: layers,
 		}
@@ -253,13 +253,14 @@ func init() {
 	}
 
 	// used in push test
-	emptyLayerManifest := imagespec.Manifest{
-		Config: imagespec.Descriptor{
-			MediaType: "application/vnd.oci.image.config.v1+json",
-			Digest:    godigest.Digest(configs[1].Digest),
-			Size:      int64(len(configs[1].Content)),
+	emptyLayerManifest := Manifest{
+		Config: Descriptor{
+			MediaType:           "application/vnd.oci.image.config.v1+json",
+			Digest:              godigest.Digest(configs[1].Digest),
+			Size:                int64(len(configs[1].Content)),
+			NewUnspecifiedField: configs[1].Content,
 		},
-		Layers: []imagespec.Descriptor{},
+		Layers: []Descriptor{},
 	}
 	emptyLayerManifest.SchemaVersion = 2
 


### PR DESCRIPTION
This change also removes the direct dependency on Go types defined in
the image-spec repo, since this made it difficult to define new fields.

Instead, the types are copied into this repo and modified to remove
unused fields, and add a new unspecified field for use in the test.

Signed-off-by: Jason Hall <jasonhall@redhat.com>

---

Note: I haven't run this against any real registries yet, I wanted to get feedback about the general direction before proceeding too much further.

cc @jdolitsky our beloved conformance czar 👑 