### PR TITLE
Build conformance images with semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,36 +13,48 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: setup go environment
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.16.2'
       - name: Prepare
         id: prepare
         run: |
           VERSION=${GITHUB_REF#refs/*/}
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          if [[ "${VERSION}" == "${BRANCH_NAME}" ]]; then
-            VERSION=$(git rev-parse --short HEAD)
+          IMAGE=ghcr.io/${{ github.repository }}/conformance
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=${GITHUB_REF#refs/heads/}
+          fi
+          VERSION=$(echo "${VERSION}" | sed -r 's#/+#-#g')
+          TAGS="${IMAGE}:${VERSION}"
+          if [[ $VERSION == "${{ github.event.repository.default_branch }}" ]]; then
+            GITSHA="$(git rev-parse --short HEAD)"
+            TAGS="${TAGS},${IMAGE}:${GITSHA}"
+          fi
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="${TAGS},${IMAGE}:${MINOR},${IMAGE}:${MAJOR}"
           fi
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=ref::ghcr.io/${{ github.repository }}/conformance:${VERSION}
-      - name: Docker Build
-        run: |
-          docker build \
-            --build-arg VERSION=${{ steps.prepare.outputs.version }} \
-            -t ${{ steps.prepare.outputs.ref }} \
-            conformance/
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Docker Login
         uses: docker/login-action@v1
+        if: github.repository_owner == 'opencontainers'
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
-      - name: Docker Push
-        run: |
-          docker push ${{ steps.prepare.outputs.ref }}
-      - name: Clear
-        if: always()
-        run: |
-          rm -f ${HOME}/.docker/config.json
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: conformance/
+          # platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: ${{ github.event_name != 'pull_request' && github.repository_owner == 'opencontainers' }}
+          tags: ${{ steps.prepare.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.version }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prepare.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
This is a rewrite of the GHA to do semver based tags, e.g. v1.0.1 would also push v1.0 and v1. This will make it possible for users to run conformance tests against the latest v1 release without needing to track the individual tags or git shas.

Signed-off-by: Brandon Mitchell <git@bmitch.net>