### PR TITLE
Add conformance test coverage for data field

### DIFF
--- a/conformance/image.go
+++ b/conformance/image.go
@@ -35,6 +35,9 @@ type Descriptor struct {
 	// Size specifies the size in bytes of the blob.
 	Size int64 `json:"size"`
 
+	// Data specifies the data of the object described by the descriptor.
+	Data []byte `json:"data"`
+
 	// NewUnspecifiedField is not covered by image-spec.
 	// Registry implementations should still successfully store and serve
 	// manifests containing this data.

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -228,7 +228,8 @@ func init() {
 				MediaType:           "application/vnd.oci.image.config.v1+json",
 				Digest:              godigest.Digest(configs[i].Digest),
 				Size:                int64(len(configs[i].Content)),
-				NewUnspecifiedField: configs[i].Content,
+				Data:                configs[i].Content,    // must be the config content.
+				NewUnspecifiedField: []byte("hello world"), // content doesn't matter.
 			},
 			Layers: layers,
 		}
@@ -258,7 +259,8 @@ func init() {
 			MediaType:           "application/vnd.oci.image.config.v1+json",
 			Digest:              godigest.Digest(configs[1].Digest),
 			Size:                int64(len(configs[1].Content)),
-			NewUnspecifiedField: configs[1].Content,
+			Data:                configs[1].Content,    // must be the config content.
+			NewUnspecifiedField: []byte("hello world"), // content doesn't matter.
 		},
 		Layers: []Descriptor{},
 	}


### PR DESCRIPTION
The `data` proposal was merged: https://github.com/opencontainers/image-spec/pull/826 🎉 

This adds some conformance test coverage that the new field is round-trippable through registries, helpfully piggybacking off of #311. Since registries don't validate that the contents match it doesn't seem fair to add that case to conformance, but it's something to consider in the future.

@jdolitsky 