### PR TITLE
clarify push manifest spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -423,6 +423,8 @@ Manifest byte stream:
 
 The uploaded manifest MUST reference any blobs that make up the artifact.
 However, the list of blobs MAY be empty.
+
+The registry MUST store the manifest in the exact byte representation provided by the client.
 Upon a successful upload, the registry MUST return response code `201 Created`, and MUST have the following header:
 
 ```
@@ -430,6 +432,8 @@ Location: <location>
 ```
 
 The `<location>` is a pullable manifest URL.
+The Docker-Content-Digest header returns the canonical digest of the uploaded blob, and MUST be equal to the client provided digest.
+Clients MAY ignore the value but if it is used, the client SHOULD verify the value against the uploaded blob data.
 
 An attempt to pull a nonexistent repository MUST return response code `404 Not Found`.
 


### PR DESCRIPTION
See discussion at: https://github.com/moby/buildkit/issues/2963

It's not currently obvious from reading the spec that manifests should be persisted in the exact wire format provided by the client, leading to errors if a registry re-formats the manifest.

This code in containerd validates the `Docker-Content-Digest` header after a manifest push, and will throw if they don't match:

https://github.com/moby/buildkit/blob/874eef9b70dbaf4f074d2bc8f4dc64237f8e83a0/vendor/github.com/containerd/containerd/remotes/docker/pusher.go#L418-L425