### PR TITLE
Working group updates

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -63,20 +63,20 @@ Several terms are used frequently in this document and warrant basic definitions
 
 - **Registry**: a service that handles the required APIs defined in this specification
 - **Client**: a tool that communicates with Registries
-- **Push**: the act of uploading Blobs and Manifests to a Registry
-- **Pull**: the act of downloading Blobs and Manifests from a Registry
-- **Blob**: the binary form of content that is stored by a Registry, addressable by a Digest
-- **Manifest**: a JSON document uploaded via the manifests endpoint. A manifest may reference other manifests and blobs in a repository via descriptors. Examples of manifests are defined under the OCI Image Spec <sup>[apdx-2](#appendix)</sup>, such as the Image Manifest, Image Index, and Artifact Manifest.</sup>
+- **Push**: the act of uploading blobs and manifests to a registry
+- **Pull**: the act of downloading blobs and manifests from a registry
+- **Blob**: the binary form of content that is stored by a registry, addressable by a digest
+- **Manifest**: a JSON document uploaded via the manifests endpoint. A manifest may reference other manifests and blobs in a repository via descriptors. Examples of manifests are defined under the OCI Image Spec <sup>[apdx-2](#appendix)</sup>, such as the image manifest, image index, and artifact manifest.</sup>
 - **Image Index**: a manifest containing a list of manifests, defined under the OCI Image Spec <sup>[apdx-6](#appendix)</sup>.
 - **Image Manifest**: a manifest containing a config descriptor and an indexed list of layers, commonly used for container images, defined under the OCI Image Spec <sup>[apdx-2](#appendix)</sup>.
 - **Artifact Manifest**: a manifest containing a collection of blobs, defined under the OCI Image Spec <sup>[apdx-7](#appendix)</sup>.
-- **Config**: a blob referenced in the Image Manifest which contains metadata. Config is defined under the OCI Image Spec <sup>[apdx-4](#appendix)</sup>.
-- **Object**: one conceptual piece of content stored as Blobs with an accompanying Manifest. (This was previously described as an "Artifact", and has been renamed to avoid confusion with the "Artifact Manifest".)
+- **Config**: a blob referenced in the image manifest which contains metadata. Config is defined under the OCI Image Spec <sup>[apdx-4](#appendix)</sup>.
+- **Object**: one conceptual piece of content stored as blobs with an accompanying manifest. (This was previously described as an "artifact", and has been renamed to avoid confusion with the "artifact manifest".)
 - **Descriptor**: a reference that describes the type, metadata and content address of referenced content. Descriptors are defined under the OCI Image Spec <sup>[apdx-5](#appendix)</sup>.
 - **Digest**: a unique identifier created from a cryptographic hash of a Blob's content. Digests are defined under the OCI Image Spec <sup>[apdx-3](#appendix)</sup>
-- **Tag**: a custom, human-readable Manifest identifier
-- **Refers**: an association from one manifest to another, typically used to attach an artifact to an image. The refers field is included in the Image and Artifact Manifests.
-- **Referrers**: a list of manifests with a Refers relationship to specified Digest. The Referrers list is generated with a [query to a Registry](#listing-referrers).
+- **Tag**: a custom, human-readable manifest identifier
+- **Refers Field**: an association from one manifest to another, typically used to attach an artifact to an image. The refers field is included in the image and artifact manifests.
+- **Referrers List**: a list of manifests with a refers relationship to specified digest. The referrers list is generated with a [query to a registry](#listing-referrers).
 
 ## Notational Conventions
 
@@ -141,9 +141,9 @@ In order to test a registry's conformance against these workflow categories, ple
 
 #### Pull
 
-The process of pulling an Object centers around retrieving two components: the manifest and one or more blobs.
+The process of pulling an object centers around retrieving two components: the manifest and one or more blobs.
 
-Typically, the first step in pulling an Object is to retrieve the manifest. However, you MAY retrieve content from the registry in any order.
+Typically, the first step in pulling an object is to retrieve the manifest. However, you MAY retrieve content from the registry in any order.
 
 ##### Pulling manifests
 
@@ -205,7 +205,7 @@ If the blob or manifest is not found in the registry, the response code MUST be 
 
 #### Push
 
-Pushing an Object typically works in the opposite order as a pull: the blobs making up the Object are uploaded first, and the manifest last.
+Pushing an object typically works in the opposite order as a pull: the blobs making up the object are uploaded first, and the manifest last.
 A useful diagram is provided [here](https://github.com/google/go-containerregistry/tree/d7f8d06c87ed209507dd5f2d723267fe35b38a9f/pkg/v1/remote#anatomy-of-an-image-upload).
 
 A registry MAY reject a manifest of any type uploaded to the manifest endpoint if it references manifests or blobs that do not exist in the registry.
@@ -432,7 +432,7 @@ Manifest byte stream:
 
 `<name>` is the namespace of the repository, and the `<reference>` MUST be either a) a digest or b) a tag.
 
-The uploaded manifest MUST reference any blobs that make up the Object.
+The uploaded manifest MUST reference any blobs that make up the object.
 However, the list of blobs MAY be empty.
 
 The registry MUST store the manifest in the exact byte representation provided by the client.
@@ -454,17 +454,17 @@ Client and registry implementations SHOULD expect to be able to support manifest
 
 ###### Pushing Manifests with Refers
 
-When pushing an Image or Artifact Manifest with the `refers` field and the [Referrers API](#listing-referrers) returns a 404, the client MUST:
+When pushing an image or artifact manifest with the `refers` field and the [referrers API](#listing-referrers) returns a 404, the client MUST:
 
-1. Pull the current Referrers list using the [referrers tag schema](#referrers-tag-schema).
-1. If that pull returns a Manifest other than the expected Image Index, the client SHOULD report a failure and skip the remaining steps.
-1. If the tag returns a 404, the client MUST begin with an empty Image Index.
-1. Verify the descriptor for the manifest is not already in the Referrers list (duplicate entries SHOULD NOT be created).
-1. Append a descriptor for the pushed Image or Artifact Manifest to the manifests in the Referrers list.
-   The value of the `artifactType` MUST be set in the descriptor to value of the `artifactType` in the Artifact Manifest, or the Config descriptor `mediaType` in the Image Manifest.
-   All annotations from the Image or Artifact Manifest MUST be copied to this descriptor.
-1. Push the updated Referrers list using the same [referrers tag schema](#referrers-tag-schema).
-   The client MAY use conditional HTTP requests to prevent overwriting a Referrers list that has changed since it was first pulled.
+1. Pull the current referrers list using the [referrers tag schema](#referrers-tag-schema).
+1. If that pull returns a manifest other than the expected image index, the client SHOULD report a failure and skip the remaining steps.
+1. If the tag returns a 404, the client MUST begin with an empty image index.
+1. Verify the descriptor for the manifest is not already in the referrers list (duplicate entries SHOULD NOT be created).
+1. Append a descriptor for the pushed image or artifact manifest to the manifests in the referrers list.
+   The value of the `artifactType` MUST be set in the descriptor to value of the `artifactType` in the artifact manifest, or the config descriptor `mediaType` in the image manifest.
+   All annotations from the image or artifact manifest MUST be copied to this descriptor.
+1. Push the updated referrers list using the same [referrers tag schema](#referrers-tag-schema).
+   The client MAY use conditional HTTP requests to prevent overwriting a referrers list that has changed since it was first pulled.
 
 #### Content Discovery
 
@@ -517,18 +517,21 @@ When using the `last` query parameter, the `n` parameter is OPTIONAL.
 *Note: this feature was added in distibution-spec 1.1.
 Registries should see [Enabling the Referrers API](#enabling-the-referrers-api) before enabling this.*
 
-To fetch the list of referrers, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<reference>` <sup>[end-12a](#endpoints)</sup>.
+To fetch the list of referrers, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<digest>` <sup>[end-12a](#endpoints)</sup>.
 
-`<name>` is the namespace of the repository.
+`<name>` is the namespace of the repository, and `<digest>` is the digest of the manifest specified in the `refers` field.
+
 Assuming a repository is found, this request MUST return a `200 OK` response code.
+If the registry supports the referrers API, the registry MUST NOT return a `404 Not Found` to a referrers API requests.
+If the request is invalid, such as a `<digest>` with an invalid syntax, a `400 Bad Request` MUST be returned.
 
-Upon success, the response MUST be a JSON body with an Image Index containing a list of descriptors.
-Each descriptor is of an Image or Artifact Manifest in the same `<name>` namespace with a `refers` field that specifies the value of `<reference>`.
-The descriptors MUST include an `artifactType` field that is set to the value of `artifactType` for an Artifact Manifest if present, or the configuration descriptor's `mediaType` for an Image Manifest.
-The descriptors MUST include annotations from the Image or Artifact Manifest.
+Upon success, the response MUST be a JSON body with an image index containing a list of descriptors.
+Each descriptor is of an image or artifact manifest in the same `<name>` namespace with a `refers` field that specifies the value of `<digest>`.
+The descriptors MUST include an `artifactType` field that is set to the value of `artifactType` for an artifact manifest if present, or the configuration descriptor's `mediaType` for an image manifest.
+The descriptors MUST include annotations from the image or artifact manifest.
 If a query results in no matching referrers, an empty manifest list MUST be returned.
-If `<ref>` does not exist, a registry MAY return an empty manifest list.
-After `<ref>` is pushed, the registry MUST include previously pushed entries in the Referrers list.
+If a manifest with the digest `<digest>` does not exist, a registry MAY return an empty manifest list.
+After a manifest with the digest `<digest>` is pushed, the registry MUST include previously pushed entries in the referrers list.
 
 ```json
 {
@@ -560,18 +563,18 @@ After `<ref>` is pushed, the registry MUST include previously pushed entries in 
 ```
 
 A `Link` header MUST be included in the response when the descriptor list cannot be returned in a single manifest.
-Each response is an Image Index with different descriptors in the `manifests` field.
+Each response is an image index with different descriptors in the `manifests` field.
 The `Link` header MUST be set according to [RFC5988](https://www.rfc-editor.org/rfc/rfc5988.html) with the Relation Type `rel="next"`.
 
 The registry SHOULD support filtering on `artifactType`.
-To fetch the list of referrers with a filter, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<reference>?artifacttype=<mediaType>` <sup>[end-12b](#endpoints)</sup>.
+To fetch the list of referrers with a filter, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<digest>?artifacttype=<mediaType>` <sup>[end-12b](#endpoints)</sup>.
 If filtering is requested and applied, the response MUST include an annotation (`org.opencontainers.referrers.filtersApplied`) denoting that an `artifactType` filter was applied.
 If multiple filters are applied, the annotation MUST contain a comma separated list of applied filters.
 
 Example request with filtering:
 
 ```
-GET /v2/<name>/referrers/<ref>?artifactType=application/vnd.example.sbom.v1
+GET /v2/<name>/referrers/<digest>?artifactType=application/vnd.example.sbom.v1
 ```
 
 Example response with filtering:
@@ -598,9 +601,9 @@ Example response with filtering:
 }
 ```
 
-If the [Referrers API](#listing-referrers) returns a 404, the client MUST fallback to pulling the [referrers tag schema](#referrers-tag-schema).
-The response SHOULD be an Image Index with the same content that would be expected from the Referrers API.
-If the response to the [Referrers API](#listing-referrers) is a 404, and the tag schema does not return a valid Image Index, the client SHOULD assume there are no Referrers to the manifest.
+If the [referrers API](#listing-referrers) returns a 404, the client MUST fallback to pulling the [referrers tag schema](#referrers-tag-schema).
+The response SHOULD be an image index with the same content that would be expected from the referrers API.
+If the response to the [referrers API](#listing-referrers) is a 404, and the tag schema does not return a valid image index, the client SHOULD assume there are no referrers to the manifest.
 
 #### Content Management
 
@@ -624,14 +627,14 @@ To delete a manifest, perform a `DELETE` request to a path in the following form
 Upon success, the registry MUST respond with a `202 Accepted` code.
 If the repository does not exist, the response MUST return `404 Not Found`.
 
-When deleting an Image or Artifact manifest that contains a `refers` field, and the [Referrers API](#listing-referrers) returns a 404, clients SHOULD:
+When deleting an image or artifact manifest that contains a `refers` field, and the [referrers API](#listing-referrers) returns a 404, clients SHOULD:
 
-1. Pull the Referrers list using the [referrers tag schema](#referrers-tag-schema).
+1. Pull the referrers list using the [referrers tag schema](#referrers-tag-schema).
 1. Remove the descriptor entry from the array of manifests that references the deleted manifest.
-1. Push the updated Referrers list using the same [referrers tag schema](#referrers-tag-schema).
-   The client MAY use conditional HTTP requests to prevent overwriting an Referrers list that has changed since it was first pulled.
+1. Push the updated referrers list using the same [referrers tag schema](#referrers-tag-schema).
+   The client MAY use conditional HTTP requests to prevent overwriting an referrers list that has changed since it was first pulled.
 
-When deleting a manifest that has an associated [referrers tag schema](#referrers-tag-schema), clients MAY also delete the referrers tag when it returns a valid Image Index.
+When deleting a manifest that has an associated [referrers tag schema](#referrers-tag-schema), clients MAY also delete the referrers tag when it returns a valid image index.
 
 ##### Deleting Blobs
 
@@ -644,12 +647,12 @@ If the blob is not found, a `404 Not Found` code MUST be returned.
 ### Backwards Compatibility
 
 Client implementations MUST support registries that implement partial or older versions of the OCI Distribution Spec.
-This section describes client fallback procedures that MUST be implemented when a new/optional API is not available from a Registry.
+This section describes client fallback procedures that MUST be implemented when a new/optional API is not available from a registry.
 
 #### Unavailable Referrers API
 
-A client that pushes an Image or Artifact Manifest with a defined `refers` field MUST verify the [Referrers API](#listing-referrers) is available or fallback to updating the Image Index pushed to a tag described by the [referrers tag schema](#referrers-tag-schema).
-A client querying the [Referrers API](#listing-referrers) and receiving a 404 MUST fallback to using an Image Index pushed to a tag described by the [referrers tag schema](#referrers-tag-schema).
+A client that pushes an image or artifact manifest with a defined `refers` field MUST verify the [referrers API](#listing-referrers) is available or fallback to updating the image index pushed to a tag described by the [referrers tag schema](#referrers-tag-schema).
+A client querying the [referrers API](#listing-referrers) and receiving a `404 Not Found` MUST fallback to using an image index pushed to a tag described by the [referrers tag schema](#referrers-tag-schema).
 
 ##### Referrers Tag Schema
 
@@ -660,13 +663,13 @@ A client querying the [Referrers API](#listing-referrers) and receiving a 404 MU
 - `<alg>`: the digest algorithm (e.g. `sha256` or `sha512`)
 - `<ref>`: the digest from the `refers` field (limit of 64 characters)
 
-For example, a manifest with the `refers` field digest set to `sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` in the `registry.example.org/project` repository would have a descriptor in the Referrers list at `registry.example.org/project:sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`.
+For example, a manifest with the `refers` field digest set to `sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` in the `registry.example.org/project` repository would have a descriptor in the referrers list at `registry.example.org/project:sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`.
 
-This tag should return an Image Index matching the expected response of the [Referrers API](#listing-referrers).
-Maintaining the content of this tag is the responsibility of clients pushing and deleting Image and Artifact Manifests that contain a `refers` field.
+This tag should return an image index matching the expected response of the [referrers API](#listing-referrers).
+Maintaining the content of this tag is the responsibility of clients pushing and deleting image and artifact manifests that contain a `refers` field.
 
-Multiple clients could attempt to update the tag simultaneously resulting in race conditions and data loss.
-Protection against race conditions is the responsibility of clients and end users, and can be resolved by using a registry that provides the [Referrers API](#listing-referrers).
+*Note*: multiple clients could attempt to update the tag simultaneously resulting in race conditions and data loss.
+Protection against race conditions is the responsibility of clients and end users, and can be resolved by using a registry that provides the [referrers API](#listing-referrers).
 Clients MAY use a conditional HTTP push for registries that support ETag conditions to avoid conflicts with other clients.
 
 ### Upgrade Procedures
@@ -675,12 +678,12 @@ The following describes procedures for upgrading to a newer version of the spec 
 
 #### Enabling the Referrers API
 
-The Referrers API here is described by [Listing Referrers](#listing-referrers) and [end-12a](#endpoints).
-When registries add support for the Referrers API, this API needs to account for manifests that were pushed before the API was available using the [Referrers Tag Schema](#referrers-tag-schema).
+The referrers API here is described by [Listing Referrers](#listing-referrers) and [end-12a](#endpoints).
+When registries add support for the referrers API, this API needs to account for manifests that were pushed before the API was available using the [Referrers Tag Schema](#referrers-tag-schema).
 
-1. Registries MUST include preexisting Image and Artifact manifests that are listed in an Image Index tagged with the [referrers tag schema](#referrers-tag-schema) and have a valid `refers` field in the Referrers API response.
-1. Registries MAY include all preexisting Image and Artifact manifests with a `refers` field in the Referrers API response.
-1. After the Referrers API is enabled, Registries MUST include all newly pushed Image and Artifact manifests with a valid `refers` field in the Referrers API response.
+1. Registries MUST include preexisting image and artifact manifests that are listed in an image index tagged with the [referrers tag schema](#referrers-tag-schema) and have a valid `refers` field in the referrers API response.
+1. Registries MAY include all preexisting image and artifact manifests with a `refers` field in the referrers API response.
+1. After the referrers API is enabled, Registries MUST include all newly pushed image and artifact manifests with a valid `refers` field in the referrers API response.
 
 ### API
 
@@ -711,8 +714,8 @@ This endpoint MAY be used for authentication/authorization purposes, but this is
 | end-9   | `DELETE`       | `/v2/<name>/manifests/<reference>`                             | `202`       | `404`/`400`/`405` |
 | end-10  | `DELETE`       | `/v2/<name>/blobs/<digest>`                                    | `202`       | `404`/`405`       |
 | end-11  | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_name>`   | `201`       | `404`             |
-| end-12a | `GET`          | `/v2/<name>/referrers/<reference>`                             | `200`       | `404`             |
-| end-12b | `GET`          | `/v2/<name>/referrers/<reference>?artifactType=<artifactType>` | `200`       | `404`             |
+| end-12a | `GET`          | `/v2/<name>/referrers/<digest>`                                | `200`       | `404`/`400`       |
+| end-12b | `GET`          | `/v2/<name>/referrers/<digest>?artifactType=<artifactType>`    | `200`       | `404`/`400`       |
 
 #### Error Codes
 


### PR DESCRIPTION
This is a follow up to #335 with changes noted in #337.

- "refers" -> "refers field"
- "referrers" -> "referrers list"
- lower case for defined words in the spec
- change `reference` to `digest` in the referrers API
- add an error code for an invalid referrers API request
- add a "*note*" to stress the risk of data loss

Signed-off-by: Brandon Mitchell <git@bmitch.net>