### PR TITLE
Fix referrers API query string example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -567,7 +567,7 @@ Each response is an image index with different descriptors in the `manifests` fi
 The `Link` header MUST be set according to [RFC5988](https://www.rfc-editor.org/rfc/rfc5988.html) with the Relation Type `rel="next"`.
 
 The registry SHOULD support filtering on `artifactType`.
-To fetch the list of referrers with a filter, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<digest>?artifacttype=<mediaType>` <sup>[end-12b](#endpoints)</sup>.
+To fetch the list of referrers with a filter, perform a `GET` request to a path in the following format: `/v2/<name>/referrers/<digest>?artifactType=<mediaType>` <sup>[end-12b](#endpoints)</sup>.
 If filtering is requested and applied, the response MUST include an annotation (`org.opencontainers.referrers.filtersApplied`) denoting that an `artifactType` filter was applied.
 If multiple filters are applied, the annotation MUST contain a comma separated list of applied filters.
 


### PR DESCRIPTION
Fix artifactType in the referrers API query string example

Signed-off-by: Jamie Wu <swu.umich@gmail.com>