### PR TITLE
Fix: #343 CI for gitvalidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ header.html: .tool/genheader.go specs-go/version.go
 install.tools: .install.gitvalidation
 
 .install.gitvalidation:
-	go get -u github.com/vbatts/git-validation
+	go install github.com/vbatts/git-validation@latest
 
 conformance: conformance-test conformance-binary
 


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

This only attempts at unblocking the CI for the repo at this point. We should have an issue to bump up the modules. Takes @sudo-bmitch's fix in part here - https://github.com/opencontainers/image-spec/blob/decdb1500673e7ef4fd912e0741f67a49e35d502/Makefile#L119-L120