### PR TITLE
Updates GHA to versions and bumps Go to 1.17

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,13 +8,20 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: ['1.17', '1.18', '1.19']
+
     steps:
       - name: checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
+
       - name: setup go environment
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.16.5'
+          go-version: ${{ matrix.go }}
+
       - name: run tests
         run: |
           export PATH="$(go env GOPATH)/bin:${PATH}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,20 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: ['1.17', '1.18', '1.19']
+
     steps:
       - name: checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
+
       - name: setup go environment
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.16.5'
+          go-version: ${{ matrix.go }}
+
       - name: run tests
         run: |
           export PATH="$(go env GOPATH)/bin:${PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Prepare
         id: prepare
         run: |
@@ -37,15 +38,17 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
       - name: Docker Login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: github.repository_owner == 'opencontainers'
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: conformance/
           # platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,3 +1,3 @@
 module github.com/opencontainers/distribution-spec/specs-go
 
-go 1.15
+go 1.17


### PR DESCRIPTION
This bumps the GHA versions to the latest versions from each, and updates Go to 1 version behind the latest supported upstream version. GHA is also setup to test against current versions of Go.

Signed-off-by: Brandon Mitchell <git@bmitch.net>