### PR TITLE
Release 1.1.0 rc1

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -20,12 +20,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
+	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = "-rc1"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1"
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Candidate commits for releasing `1.1.0-rc1` and switch back to dev and bump main branch version to `1.1.0-dev`

This follows precedence similar to - https://github.com/opencontainers/distribution-spec/pull/274/commits

Tied to https://github.com/opencontainers/image-spec/pull/953