### PR TITLE
Add a header with manifest tag to pull and push

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -157,6 +157,10 @@ The `Content-Type` header SHOULD match what the client [pushed as the manifest's
 If the manifest has a `mediaType` field, clients SHOULD reject unless the `mediaType` field's value matches the type specified by the `Content-Type` header.
 For more information on the use of `Accept` headers and content negotiation, please see [Content Negotiation](./content-negotiation.md).
 
+The client SHOULD include a `Docker-Manifest-Tag` header indicating which manifest tag is being pulled.
+This header SHOULD be added to all requests throughout the pull process.
+Registries MAY use this value as a hint when handling the pulled manifests and blobs.
+
 A GET request to an existing manifest URL MUST provide the expected manifest, with a response code that MUST be `200 OK`.
 A successful response SHOULD contain the digest of the uploaded blob in the header `Docker-Content-Digest`.
 
@@ -200,6 +204,10 @@ A useful diagram is provided [here](https://github.com/google/go-containerregist
 
 A registry MAY reject a manifest of any type uploaded to the manifest endpoint if it references manifests or blobs that do not exist in the registry.
 When a manifest is rejected for this reason, it must result in one or more `MANIFEST_BLOB_UNKNOWN` errors <sup>[code-1](#error-codes)</sup>.
+
+The client SHOULD include a `Docker-Manifest-Tag` header indicating which manifest tag is being pushed.
+This header SHOULD be added to all requests throughout the push process.
+Registries MAY use this value as a hint when handling the pushed manifests and blobs.
 
 ##### Pushing blobs
 


### PR DESCRIPTION
Signed-off-by: Yinon Avraham <yinona@jfrog.com>

Add an optional request header `Docker-Manifest-Tag` to all requests in the push and pull operations.
This request header, when added, shall include the tag value of the image being pushed / pulled.

For example, when pushing or pulling image `foo:1.2`, the following header will be added to all requests:
```
Docker-Manifest-Tag: 1.2
```

Registries can then use this header, if it exists, for various use cases. For example:
* In the `/v2/` (ping) request - to identify the specific requested tag and by that limit the authorization request (auth challenge), making the authorization grant specific to that tag
* In the `.../blobs/...` requests - optimize locating blobs while they are being pushed or pulled. This is useful in registry implementations which keep a link between tags and their blobs