### PR TITLE
Specify accepted manifest types

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -209,6 +209,7 @@ Pushing an object typically works in the opposite order as a pull: the blobs mak
 A useful diagram is provided [here](https://github.com/google/go-containerregistry/tree/d7f8d06c87ed209507dd5f2d723267fe35b38a9f/pkg/v1/remote#anatomy-of-an-image-upload).
 
 A registry MAY reject a manifest of any type uploaded to the manifest endpoint if it references manifests or blobs that do not exist in the registry.
+A registry MUST accept  manifests of OCI image index<sup>[apdx-6](#appendix)</sup>, OCI image manifest<sup>[apdx-2](#appendix)</sup> and OCI artifact manifest<sup>[apdx-7](#appendix)</sup> type.
 A registry MUST accept an otherwise valid manifest with a `subject` field that references a manifest that does not exist, allowing clients to push a manifest and referrers to that manifest in either order.
 When a manifest is rejected for these reasons, it MUST result in one or more `MANIFEST_BLOB_UNKNOWN` errors <sup>[code-1](#error-codes)</sup>.
 


### PR DESCRIPTION
The distribution spec does not explicitly state the types of manifest supported and this PR helps clarify that so that when v1.1 of the spec is tagged, implementations should support all 3 manifest types if they are to claim conformance. 

If there is a capability endpoint that calls out the version or manifest types then all three manifest types should be supported - refer - https://github.com/opencontainers/distribution-spec/issues/365

Signed-off-by: Sajay Antony <sajaya@microsoft.com>