### PR TITLE
Add Go 1.20 support

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.18', '1.19', '1.20']
 
     steps:
       - name: checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.18', '1.19', '1.20']
 
     steps:
       - name: checkout source code

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,3 +1,3 @@
 module github.com/opencontainers/distribution-spec/specs-go
 
-go 1.17
+go 1.18


### PR DESCRIPTION
Added Go 1.20 to GitHub actions matrix and dropped Go 1.17

Signed-off-by: Austin Vazquez <macedonv@amazon.com>