### PR TITLE
Specify `Warning` header usage

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -23,7 +23,7 @@
 - [API](#api)
 	- [Endpoints](#endpoints)
 	- [Error Codes](#error-codes)
-    - [Warnings](#warnings)
+	- [Warnings](#warnings)
 - [Appendix](#appendix)
 
 

--- a/spec.md
+++ b/spec.md
@@ -23,6 +23,7 @@
 - [API](#api)
 	- [Endpoints](#endpoints)
 	- [Error Codes](#error-codes)
+    - [Warnings](#warnings)
 - [Appendix](#appendix)
 
 
@@ -757,6 +758,26 @@ The `code` field MUST be one of the following:
 | code-12 | `DENIED`                | requested access to the resource is denied                 |
 | code-13 | `UNSUPPORTED`           | the operation is unsupported                               |
 | code-14 | `TOOMANYREQUESTS`       | too many requests                                          |
+
+#### Warnings
+
+Registry implementations MAY include informational warnings in `Warning` headers, as described in [RFC 7234](https://www.rfc-editor.org/rfc/rfc7234#section-5.5).
+
+If included, `Warning` headers MUST specify a `warn-code` of `299` and a `warn-agent` of `-`, and MUST NOT specify a `warn-date` value.
+
+A registry MUST NOT send more than 4096 bytes of warning data from all headers combined.
+
+Example warning headers:
+
+```
+Warning: 299 - "Your auth token will expire in 30 seconds."
+Warning: 299 - "This registry endpoint is deprecated and will be removed soon."
+Warning: 299 - "This image is deprecated and will be removed soon."
+```
+
+If a client receives `Warning` response headers, it SHOULD report the warnings to the user in an unobtrusive way.
+Clients SHOULD deduplicate warnings from multiple associated responses.
+In accordance with RFC 7234, clients MUST NOT take any automated action based on the presence or contents of warnings, only report them to the user.
 
 ### Appendix
 


### PR DESCRIPTION
Fixes https://github.com/opencontainers/distribution-spec/issues/390

This is _heavily_ inspired by Kubernetes' support for warnings returned by the API server and surfaced by clients like `kubectl`: https://kubernetes.io/blog/2020/09/03/warnings/

tl;dr: Registries MAY return informational warning messages in the `Warning` header, as described in https://www.rfc-editor.org/rfc/rfc7234#section-5.5, with the added restriction that the `warn-code` must be 299 and the `warn-agent` must be unset (`-`). Clients SHOULD surface those messages to the user in an unobtrusive and helpful way -- how they do that is up to them.

Blatantly cribbing further helpful advice from https://github.com/opencontainers/distribution-spec/issues/390#issuecomment-1472827380:

> From https://kubernetes.io/blog/2020/09/03/warnings/#admission-webhooks
>
> > If you are implementing a webhook that returns a warning message, here are some tips:
> >
> > - Don't include a "Warning:" prefix in the message (that is added by clients on output)
> > - Use warning messages to describe problems the client making the API request should correct or be aware of
> > - Be brief; limit warnings to 120 characters if possible

and from https://github.com/opencontainers/distribution-spec/issues/390#issuecomment-1472832235

>  One more side note: a key provision of the warnings RFC is that for warnings returned with code 299: "A system receiving this warning MUST NOT take any automated action." Kubernetes leans heavily on this to assume it is always safe to return a warning or stop returning a warning without backwards compatibility implications. You would think it goes without saying, but warning header contents are not APIs.

cc @BenTheElder @liggitt 

@jonjohnsonjr @jdolitsky @sudo-bmitch @sajayantony 
