### PR TITLE
conformance: make blob mount and upload checks more strict

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -277,7 +277,7 @@ var test02Push = func() {
 					Equal(http.StatusCreated),
 					Equal(http.StatusAccepted),
 				))
-				Expect(resp.GetRelativeLocation()).To(ContainSubstring(crossmountNamespace))
+				Expect(resp.GetRelativeLocation()).To(Equal(fmt.Sprintf("/v2/%s/blobs/%s", crossmountNamespace, testBlobADigest)))
 
 				lastResponse = resp
 			})
@@ -296,8 +296,7 @@ var test02Push = func() {
 				SkipIfDisabled(push)
 				RunOnlyIf(lastResponse.StatusCode() == http.StatusAccepted)
 
-				loc := lastResponse.GetRelativeLocation()
-				Expect(loc).To(ContainSubstring("/blobs/uploads/"))
+				Expect(lastResponse.GetRelativeLocation()).To(HavePrefix(fmt.Sprintf("/v2/%s/blobs/uploads/", crossmountNamespace)))
 			})
 
 			g.Specify("Cross-mounting without from, and automatic content discovery enabled should return a 201", func() {


### PR DESCRIPTION
1. when mounting is successful, require the `Location` response header to be exactly `/v2/<repo>/blobs/<digest>`, and not just contain the string `<repo>`
2. when mounting is unsuccessful and `Location` points to an upload session URL, require the `Location` response header to start with `/v2/<repo>/blobs/uploads/`, and not just contain `/blobs/uploads/`.

In the case of (2), this corresponds to common behavior, but based on my reading of the spec it might not actually be exactly specified as such:

> Alternatively, if a registry does not support cross-repository mounting or is unable to mount the requested blob, it SHOULD return a 202. This indicates that the upload session has begun and that the client MAY proceed with the upload.

([source](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#mounting-a-blob-from-another-repository))

We may want to clarify this failed-mounting behavior more to specify that the `Location` response header MUST be `/v2/<repo>/blobs/uploads/`, as it normally is.