### PR TITLE
releases: use +dev as in-development suffix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -64,7 +64,7 @@ Releases usually follow a few steps:
     * [ ] merge multi-commit PRs (so each line has a `(#num)` suffix)
     * [ ] drop hash and indent, `:'<,'> s/^\w*  /^I* /`
   * [ ] a commit bumping `./specs-go/version.go` to next version and empty the `VersionDev` variable
-  * [ ] a commit adding back the "-dev" to `VersionDev`
+  * [ ] a commit adding back the "+dev" to `VersionDev`
 * [ ] send email to dev@opencontainers.org
   * [ ] copy the exact commit hash for bumping the version from the pull-request (since master always stays as "-dev")
   * [ ] count the PRs since last release (that this version is tracking, in the cases of multiple branching), like `git log --pretty=oneline --no-merges --decorate $priorTag..$versionBumpCommit  | grep \(pr\/ | wc -l`

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.2-dev"
+	VersionDev = "-rc.2+dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This mirrors PRs to the other specs:

https://github.com/opencontainers/runtime-spec/pull/1198
https://github.com/opencontainers/image-spec/pull/1050