### PR TITLE
conformance: do not fail on report generation failure

### DIFF
--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -526,6 +526,12 @@ func (reporter *HTMLReporter) save(snapshot *specSnapshot) {
 }
 
 func (reporter *HTMLReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	if err := reporter.writeReport(summary); err != nil {
+		log.Printf("WARNING: cannot write HTML summary report: %v", err)
+	}
+}
+
+func (reporter *HTMLReporter) writeReport(summary *types.SuiteSummary) error {
 	reporter.endTime = time.Now()
 	reporter.EndTimeString = reporter.endTime.Format("Jan 2 15:04:05.000 -0700 MST")
 	reporter.RunTime = reporter.endTime.Sub(reporter.startTime).String()
@@ -539,26 +545,27 @@ func (reporter *HTMLReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 
 	t, err := template.New("report").Parse(htmlTemplate)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("cannot parse report template: %v", err)
 	}
 
 	htmlReportFilenameAbsPath, err := filepath.Abs(reporter.htmlReportFilename)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	htmlReportFile, err := os.Create(htmlReportFilenameAbsPath)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer htmlReportFile.Close()
 
 	err = t.ExecuteTemplate(htmlReportFile, "report", &reporter)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	fmt.Printf("HTML report was created: %s", htmlReportFilenameAbsPath)
+	return nil
 }
 
 //unused by HTML reporter


### PR DESCRIPTION
When the conformance test package cannot write to the current directory, it calls `log.Fatal` and exits immediately, making it look like the tests have failed even when they haven't.

This can happen when the conformance tests are run without checking out the repository, as in:
```
	go test github.com/opencontainers/distribution-spec/conformance
```
which is possible (and useful) when using the conformance tests as a dependency in some other module. In this case, the files are in a read-only directory inside `$GOMODCACHE`.

This change makes the failure soft, so it will print a warning, but not actually fail the tests. This matches the behaviour of `reporters.NewJUnitReporter`.