### PR TITLE
conformance: check response status before checking location

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -233,8 +233,8 @@ var test02Push = func() {
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				location := resp.Header().Get("Location")
-				Expect(location).ToNot(BeEmpty())
 				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
+				Expect(location).ToNot(BeEmpty())
 				lastResponse = resp
 			})
 
@@ -246,9 +246,9 @@ var test02Push = func() {
 					SetQueryParam("digest", testBlobBDigest)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 			})
 		})
 


### PR DESCRIPTION
I noticed that when these tests are running against a server that returns the wrong status code (an error, for example), the failure that we see doesn't mention the status code, but only that the returned location is empty.

This change checks the status code first, as if that's wrong, the location is very unlikely to be relevant.