### PR TITLE
conformance: skip check (by default) for zero layers in image manifest 

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -350,16 +350,19 @@ var test02Push = func() {
 
 			g.Specify("Registry should accept a manifest upload with no layers", func() {
 				SkipIfDisabled(push)
-				RunOnlyIfNot(skipEmptyLayerTest)
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(emptyLayerTestTag)).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
 					SetBody(emptyLayerManifestContent)
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
-				location := resp.Header().Get("Location")
-				Expect(location).ToNot(BeEmpty())
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				if resp.StatusCode() == http.StatusCreated {
+					location := resp.Header().Get("Location")
+					Expect(location).ToNot(BeEmpty())
+					Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				} else {
+					Warn("image manifest with no layers is not supported")
+				}
 			})
 
 			g.Specify("GET request to manifest URL (digest) should yield 200 response", func() {

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -15,6 +15,7 @@ var test02Push = func() {
 	g.Context(titlePush, func() {
 
 		var lastResponse, prevResponse *reggie.Response
+		var emptyLayerManifestRef string
 
 		g.Context("Setup", func() {
 			// No setup required at this time for push tests
@@ -358,6 +359,7 @@ var test02Push = func() {
 				Expect(err).To(BeNil())
 				if resp.StatusCode() == http.StatusCreated {
 					location := resp.Header().Get("Location")
+					emptyLayerManifestRef = location
 					Expect(location).ToNot(BeEmpty())
 					Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 				} else {
@@ -390,6 +392,18 @@ var test02Push = func() {
 						),
 						Equal(http.StatusMethodNotAllowed),
 					))
+					if emptyLayerManifestRef != "" {
+						req = client.NewRequest(reggie.DELETE, emptyLayerManifestRef)
+						resp, err = client.Do(req)
+						Expect(err).To(BeNil())
+						Expect(resp.StatusCode()).To(SatisfyAny(
+							SatisfyAll(
+								BeNumerically(">=", 200),
+								BeNumerically("<", 300),
+							),
+							Equal(http.StatusMethodNotAllowed),
+						))
+					}
 				})
 			}
 
@@ -437,6 +451,18 @@ var test02Push = func() {
 						),
 						Equal(http.StatusMethodNotAllowed),
 					))
+					if emptyLayerManifestRef != "" {
+						req = client.NewRequest(reggie.DELETE, emptyLayerManifestRef)
+						resp, err = client.Do(req)
+						Expect(err).To(BeNil())
+						Expect(resp.StatusCode()).To(SatisfyAny(
+							SatisfyAll(
+								BeNumerically(">=", 200),
+								BeNumerically("<", 300),
+							),
+							Equal(http.StatusMethodNotAllowed),
+						))
+					}
 				})
 			}
 		})

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -10,11 +10,13 @@ import (
 	"math/big"
 	mathrand "math/rand"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/bloodorangeio/reggie"
 	"github.com/google/uuid"
 	g "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/formatter"
 	godigest "github.com/opencontainers/go-digest"
 )
 
@@ -128,7 +130,6 @@ var (
 	runPushSetup               bool
 	runContentDiscoverySetup   bool
 	runContentManagementSetup  bool
-	skipEmptyLayerTest         bool
 	deleteManifestBeforeBlobs  bool
 	runAutomaticCrossmountTest bool
 	automaticCrossmountEnabled bool
@@ -309,7 +310,6 @@ func init() {
 	runPushSetup = true
 	runContentDiscoverySetup = true
 	runContentManagementSetup = true
-	skipEmptyLayerTest = false
 	deleteManifestBeforeBlobs = true
 
 	if os.Getenv(envVarTagName) != "" &&
@@ -322,7 +322,6 @@ func init() {
 		runContentDiscoverySetup = false
 	}
 
-	skipEmptyLayerTest, _ = strconv.ParseBool(os.Getenv(envVarPushEmptyLayer))
 	if v, ok := os.LookupEnv(envVarDeleteManifestBeforeBlobs); ok {
 		deleteManifestBeforeBlobs, _ = strconv.ParseBool(v)
 	}
@@ -352,6 +351,14 @@ func RunOnlyIfNot(v bool) {
 	if v {
 		g.Skip("you have skipped this test.")
 	}
+}
+
+func Warn(message string) {
+	// print message
+	fmt.Fprint(os.Stderr, formatter.Fi(2, "\n{{magenta}}WARNING: %s\n{{/}}", message))
+	// print file:line
+	_, file, line, _ := runtime.Caller(1)
+	fmt.Fprint(os.Stderr, formatter.Fi(2, "\n%s:%d\n", file, line))
 }
 
 func generateSkipReport() string {


### PR DESCRIPTION
As per image-spec, since this is a SHOULD (hence recommended) ...

https://raw.githubusercontent.com/opencontainers/image-spec/main/manifest.md

===

layers array of objects

Each item in the array MUST be a descriptor. For portability, layers SHOULD have at least one entry.

===

Fixes #410