### PR TITLE
spec: more liberal separator for repository names

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -73,7 +73,7 @@ Several terms are used frequently in this document and warrant basic definitions
 - **Descriptor**: a reference that describes the type, metadata and content address of referenced content. Descriptors are defined under the OCI Image Spec <sup>[apdx-5](#appendix)</sup>.
 - **Digest**: a unique identifier created from a cryptographic hash of a Blob's content. Digests are defined under the OCI Image Spec <sup>[apdx-3](#appendix)</sup>
 - **Tag**: a custom, human-readable manifest identifier
-- **Subject**: an association from one manifest to another, typically used to attach an artifact to an image. 
+- **Subject**: an association from one manifest to another, typically used to attach an artifact to an image.
 - **Referrers List**: a list of manifests with a subject relationship to a specified digest. The referrers list is generated with a [query to a registry](#listing-referrers).
 
 ## Notational Conventions
@@ -153,7 +153,7 @@ To pull a manifest, perform a `GET` request to a URL in the following form:
 The `<reference>` MUST NOT be in any other format.
 Throughout this document, `<name>` MUST match the following regular expression:
 
-`[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*`
+`[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+(\.|_|__|-+)[a-z0-9]+)*)*`
 
 Throughout this document, `<reference>` as a tag MUST be at most 128 characters in length and MUST match the following regular expression:
 


### PR DESCRIPTION
This change makes the separators consistent with the implementation in the Docker distribution [here](https://github.com/distribution/distribution/blob/97b1d649c4938d0f608d96454d6a8326b1f96acd/reference/regexp.go#L53).

Relevant parts from that code:

```
separator = `(?:[._]|__|[-]+)`
pathComponent = alphanumeric + anyTimes(separator+alphanumeric)
remoteName = pathComponent + anyTimes(`/`+pathComponent)
namePat    = optional(domainAndPort+`/`) + remoteName
```