### PR TITLE
spec: fix regexp

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -153,7 +153,7 @@ To pull a manifest, perform a `GET` request to a URL in the following form:
 The `<reference>` MUST NOT be in any other format.
 Throughout this document, `<name>` MUST match the following regular expression:
 
-`[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+(\.|_|__|-+)[a-z0-9]+)*)*`
+`[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*`
 
 Throughout this document, `<reference>` as a tag MUST be at most 128 characters in length and MUST match the following regular expression:
 


### PR DESCRIPTION
As pointed out by @andaaron in #425, the regular expression proposed there was bogus. It was actually wrong in two different ways. Mea culpa, my apologies.

This fixes it. I wrote a few test cases to check: https://go.dev/play/p/4_iYH4Hao1-

```go
package main

import (
	"regexp"
	"testing"
)

func TestRepoPattern(t *testing.T) {
	r := regexp.MustCompile(`^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*$`)
	for _, test := range []struct {
		s    string
		want bool
	}{
		{"foo", true},
		{"foo/bar", true},
		{"foo/bar__baz", true},
		{"foo/bar___baz", false},
		{"/foo", false},
		{"foo//bar", false},
		{"foo-------b__x.com", true},
		{"foo-------b__x.com/p----x", true},
		{"foo-", false},
		{"-foo", false},
		{"foo/-bar", false},
		{"foo/bar-", false},
		{"foo-bar", true},
		{"foo----_bar", false},
		{"foo----bar_/x", false},
	} {
		if got, want := r.MatchString(test.s), test.want; got != want {
			t.Errorf("mismatch on %q; got %v want %v", test.s, got, want)
		}
	}
}
```

Ideally something like the above would be committed for CI testing but perhaps that's a stage too far.