### PR TITLE
Fix delete of empty layer manifest

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -393,7 +393,7 @@ var test02Push = func() {
 						Equal(http.StatusMethodNotAllowed),
 					))
 					if emptyLayerManifestRef != "" {
-						req = client.NewRequest(reggie.DELETE, emptyLayerManifestRef)
+						req = client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>", reggie.WithReference(emptyLayerManifestDigest))
 						resp, err = client.Do(req)
 						Expect(err).To(BeNil())
 						Expect(resp.StatusCode()).To(SatisfyAny(
@@ -452,7 +452,7 @@ var test02Push = func() {
 						Equal(http.StatusMethodNotAllowed),
 					))
 					if emptyLayerManifestRef != "" {
-						req = client.NewRequest(reggie.DELETE, emptyLayerManifestRef)
+						req = client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>", reggie.WithReference(emptyLayerManifestDigest))
 						resp, err = client.Do(req)
 						Expect(err).To(BeNil())
 						Expect(resp.StatusCode()).To(SatisfyAny(

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -133,6 +133,7 @@ var (
 	layerBlobDigest                    string
 	layerBlobContentLength             string
 	emptyLayerManifestContent          []byte
+	emptyLayerManifestDigest           string
 	nonexistentManifest                string
 	emptyJSONBlob                      []byte
 	emptyJSONDescriptor                Descriptor
@@ -299,6 +300,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	emptyLayerManifestDigest = string(godigest.FromBytes(emptyLayerManifestContent))
 
 	nonexistentManifest = ".INVALID_MANIFEST_NAME"
 	invalidManifestContent = []byte("blablabla")


### PR DESCRIPTION
I was seeing failures running conformance tests against distribution/distribution because the returned "location" header is not a digest that can be deleted.