### PR TITLE
Vendored image-spec should be private

### DIFF
--- a/conformance/05_referrers.go
+++ b/conformance/05_referrers.go
@@ -192,7 +192,7 @@ var test05Referrers = func() {
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 
-				var index Index
+				var index index
 				err = json.Unmarshal(resp.Body(), &index)
 				Expect(err).To(BeNil())
 				Expect(len(index.Manifests)).To(BeZero())
@@ -209,7 +209,7 @@ var test05Referrers = func() {
 					Expect(h).To(Equal(configs[4].Digest))
 				}
 
-				var index Index
+				var index index
 				err = json.Unmarshal(resp.Body(), &index)
 				Expect(err).To(BeNil())
 				Expect(len(index.Manifests)).To(Equal(4))
@@ -228,7 +228,7 @@ var test05Referrers = func() {
 					Expect(h).To(Equal(configs[4].Digest))
 				}
 
-				var index Index
+				var index index
 				err = json.Unmarshal(resp.Body(), &index)
 				Expect(err).To(BeNil())
 

--- a/conformance/image.go
+++ b/conformance/image.go
@@ -9,8 +9,8 @@ import (
 // conformance tests, and to add new unspecified fields, to test registry
 // conformance in handling unknown fields.
 
-// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
-type Manifest struct {
+// manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
+type manifest struct {
 	// SchemaVersion is the image manifest schema that this image follows
 	SchemaVersion int `json:"schemaVersion"`
 
@@ -19,19 +19,19 @@ type Manifest struct {
 
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
-	Config Descriptor `json:"config"`
+	Config descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []Descriptor `json:"layers"`
+	Layers []descriptor `json:"layers"`
 
 	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
-	Subject *Descriptor `json:"subject,omitempty"`
+	Subject *descriptor `json:"subject,omitempty"`
 }
 
-// Descriptor describes the disposition of targeted content.
+// descriptor describes the disposition of targeted content.
 // This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
 // when marshalled to JSON.
-type Descriptor struct {
+type descriptor struct {
 	// MediaType is the media type of the object this schema refers to.
 	MediaType string `json:"mediaType,omitempty"`
 
@@ -50,8 +50,8 @@ type Descriptor struct {
 	NewUnspecifiedField []byte `json:"newUnspecifiedField"`
 }
 
-// RootFS describes a layer content addresses
-type RootFS struct {
+// rootFS describes a layer content addresses
+type rootFS struct {
 	// Type is the type of the rootfs.
 	Type string `json:"type"`
 
@@ -59,9 +59,9 @@ type RootFS struct {
 	DiffIDs []digest.Digest `json:"diff_ids"`
 }
 
-// Image is the JSON structure which describes some basic information about the image.
+// image is the JSON structure which describes some basic information about the image.
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
-type Image struct {
+type image struct {
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`
 
@@ -75,12 +75,12 @@ type Image struct {
 	OS string `json:"os"`
 
 	// RootFS references the layer content addresses used by the image.
-	RootFS RootFS `json:"rootfs"`
+	RootFS rootFS `json:"rootfs"`
 }
 
-// Index references manifests for various platforms.
+// index references manifests for various platforms.
 // This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
-type Index struct {
+type index struct {
 	// SchemaVersion is the image manifest schema that this image follows
 	SchemaVersion int `json:"schemaVersion"`
 
@@ -88,7 +88,7 @@ type Index struct {
 	MediaType string `json:"mediaType,omitempty"`
 
 	// Manifests references platform specific manifests.
-	Manifests []Descriptor `json:"manifests"`
+	Manifests []descriptor `json:"manifests"`
 
 	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -135,7 +135,7 @@ var (
 	emptyLayerManifestContent          []byte
 	nonexistentManifest                string
 	emptyJSONBlob                      []byte
-	emptyJSONDescriptor                Descriptor
+	emptyJSONDescriptor                descriptor
 	refsManifestAConfigArtifactContent []byte
 	refsManifestAConfigArtifactDigest  string
 	refsManifestALayerArtifactContent  []byte
@@ -207,10 +207,10 @@ func init() {
 		// in order to get a unique blob digest, we create a new author
 		// field for the config on each run.
 		randomAuthor := randomString(16)
-		config := Image{
+		config := image{
 			Architecture: "amd64",
 			OS:           "linux",
-			RootFS: RootFS{
+			RootFS: rootFS{
 				Type:    "layers",
 				DiffIDs: []godigest.Digest{},
 			},
@@ -244,7 +244,7 @@ func init() {
 	layerBlobDigest = layerBlobDigestRaw.String()
 	layerBlobContentLength = fmt.Sprintf("%d", len(layerBlobData))
 
-	layers := []Descriptor{{
+	layers := []descriptor{{
 		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 		Size:      int64(len(layerBlobData)),
 		Digest:    layerBlobDigestRaw,
@@ -252,8 +252,8 @@ func init() {
 
 	// create a unique manifest for each workflow category
 	for i := 0; i < numWorkflows; i++ {
-		manifest := Manifest{
-			Config: Descriptor{
+		manifest := manifest{
+			Config: descriptor{
 				MediaType:           "application/vnd.oci.image.config.v1+json",
 				Digest:              godigest.Digest(configs[i].Digest),
 				Size:                int64(len(configs[i].Content)),
@@ -283,15 +283,15 @@ func init() {
 	}
 
 	// used in push test
-	emptyLayerManifest := Manifest{
-		Config: Descriptor{
+	emptyLayerManifest := manifest{
+		Config: descriptor{
 			MediaType:           "application/vnd.oci.image.config.v1+json",
 			Digest:              godigest.Digest(configs[1].Digest),
 			Size:                int64(len(configs[1].Content)),
 			Data:                configs[1].Content,    // must be the config content.
 			NewUnspecifiedField: []byte("hello world"), // content doesn't matter.
 		},
-		Layers: []Descriptor{},
+		Layers: []descriptor{},
 	}
 	emptyLayerManifest.SchemaVersion = 2
 
@@ -312,7 +312,7 @@ func init() {
 
 	// used in referrers test (artifacts with Subject field set)
 	emptyJSONBlob = []byte("{}")
-	emptyJSONDescriptor = Descriptor{
+	emptyJSONDescriptor = descriptor{
 		MediaType: "application/vnd.oci.empty.v1+json",
 		Size:      int64(len(emptyJSONBlob)),
 		Digest:    godigest.FromBytes(emptyJSONBlob),
@@ -331,17 +331,17 @@ func init() {
 	testRefArtifactTypeB = "application/vnd.nba.strawberry.jam.croissant"
 
 	// artifact with Subject ref using config.MediaType = artifactType
-	refsManifestAConfigArtifact := Manifest{
-		Config: Descriptor{
+	refsManifestAConfigArtifact := manifest{
+		Config: descriptor{
 			MediaType: testRefArtifactTypeA,
 			Size:      int64(len(testRefBlobA)),
 			Digest:    godigest.FromBytes(testRefBlobA),
 		},
-		Subject: &Descriptor{
+		Subject: &descriptor{
 			Size:   int64(len(manifests[4].Content)),
 			Digest: godigest.FromBytes(manifests[4].Content),
 		},
-		Layers: []Descriptor{
+		Layers: []descriptor{
 			emptyJSONDescriptor,
 		},
 	}
@@ -353,17 +353,17 @@ func init() {
 
 	refsManifestAConfigArtifactDigest = godigest.FromBytes(refsManifestAConfigArtifactContent).String()
 
-	refsManifestBConfigArtifact := Manifest{
-		Config: Descriptor{
+	refsManifestBConfigArtifact := manifest{
+		Config: descriptor{
 			MediaType: testRefArtifactTypeB,
 			Size:      int64(len(testRefBlobB)),
 			Digest:    godigest.FromBytes(testRefBlobB),
 		},
-		Subject: &Descriptor{
+		Subject: &descriptor{
 			Size:   int64(len(manifests[4].Content)),
 			Digest: godigest.FromBytes(manifests[4].Content),
 		},
-		Layers: []Descriptor{
+		Layers: []descriptor{
 			emptyJSONDescriptor,
 		},
 	}
@@ -376,15 +376,15 @@ func init() {
 	refsManifestBConfigArtifactDigest = godigest.FromBytes(refsManifestBConfigArtifactContent).String()
 
 	// artifact with Subject ref using ArtifactType, config.MediaType = emptyJSON
-	refsManifestALayerArtifact := Manifest{
+	refsManifestALayerArtifact := manifest{
 		ArtifactType: testRefArtifactTypeA,
 		Config:       emptyJSONDescriptor,
-		Subject: &Descriptor{
+		Subject: &descriptor{
 			Size:   int64(len(manifests[4].Content)),
 			Digest: godigest.FromBytes(manifests[4].Content),
 		},
-		Layers: []Descriptor{
-			Descriptor{
+		Layers: []descriptor{
+			descriptor{
 				MediaType: testRefArtifactTypeA,
 				Size:      int64(len(testRefBlobB)),
 				Digest:    godigest.FromBytes(testRefBlobB),
@@ -399,15 +399,15 @@ func init() {
 
 	refsManifestALayerArtifactDigest = godigest.FromBytes(refsManifestALayerArtifactContent).String()
 
-	refsManifestBLayerArtifact := Manifest{
+	refsManifestBLayerArtifact := manifest{
 		ArtifactType: testRefArtifactTypeB,
 		Config:       emptyJSONDescriptor,
-		Subject: &Descriptor{
+		Subject: &descriptor{
 			Size:   int64(len(manifests[4].Content)),
 			Digest: godigest.FromBytes(manifests[4].Content),
 		},
-		Layers: []Descriptor{
-			Descriptor{
+		Layers: []descriptor{
+			descriptor{
 				MediaType: testRefArtifactTypeB,
 				Size:      int64(len(testRefBlobB)),
 				Digest:    godigest.FromBytes(testRefBlobB),


### PR DESCRIPTION
There's no need to export these types. They are internal, for testing only.