### PR TITLE
tag 1.1.0-rc3

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3"
+	VersionDev = "-rc.3+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.2+dev"
+	VersionDev = "-rc.3"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## tag

This would mean tagging https://github.com/opencontainers/distribution-spec/commit/79571f3211c620a7b84fcc8a949577e06b36db1e as v1.1.0-rc3

## changes

79571f3 version: bump for release of v1.1.0-rc.3
46cff19 conformance: make references tests part of content discovery workflow (#430)
e0e2768 Vendored image-spec should be private (#429)
215045b Fix delete of empty layer manifest (#428)
657d95d Test pull of manifest pushed by digest (#427)
f49a193 Merge pull request #419 from rogpeppe-contrib/001-no-fail-on-no-report
efe2de0 spec: fix regexp (#426)
a738357 spec: more liberal separator for repository names (#425)
99aba31 conformance: initial commit for refererrers test (#375)
c76f05b conformance: skip check (by default) for zero layers in image manifest  (#421)
d729b7a README.md: remove a dead link to chat.opencontainers.org (#422)
a1eadff conformance: check response status before checking location (#420)
135780a Fix incorrect test HTTP method (#331)
73fe777 Conformance: fix inappropriate test HTTP method (#332)
aef0f61 fix: delete manifest before blobs by default (#423)
adeb3ac adds some description for adding dist extensions (#302)
58a1fe9 Merge pull request #417 from sudo-bmitch/pr-release-dev-suffix
caded17 conformance: do not fail on report generation failure
7d2d9ff releases: use +dev as in-development suffix
7fcdf80 Merge pull request #411 from imjasonh/patch-2
09d29b1 Update README.md
57b69b6 Merge pull request #407 from brackendawson/aahtifacts
8e2a64e Remove over-constrained references to manifests
529f2d1 Remove references to artifact manifest and artifact manfiest
efe6bee Merge pull request #403 from vbatts/prep-1.1-rc.2
a3b708a version: roll HEAD back to -dev

## diff

https://github.com/opencontainers/distribution-spec/compare/v1.1.0-rc2...jdolitsky:distribution-spec:79571f3

## votes

 - [ ] @sudo-bmitch
 - [ ] @dmcgowan
 - [x] @jzelinskie
 - [x] @jonjohnsonjr
 - [ ] @jdolitsky
 - [x] @mikebrow
 - [x] @stevvooe
 - [x] @vbatts