### PR TITLE
conformance: fix artifact layers content in setup

### DIFF
--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -393,8 +393,8 @@ func init() {
 		Layers: []descriptor{
 			{
 				MediaType: testRefArtifactTypeA,
-				Size:      int64(len(testRefBlobB)),
-				Digest:    godigest.FromBytes(testRefBlobB),
+				Size:      int64(len(testRefBlobA)),
+				Digest:    godigest.FromBytes(testRefBlobA),
 			},
 		},
 	}


### PR DESCRIPTION
This was a typo in the test setup. We create two artifacts A and B with both config.media-type and layers model.