### PR TITLE
conformance: OCI-Filters-Applied should return a literal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ conformance-test:
 
 conformance-binary: $(OUTPUT_DIRNAME)/conformance.test
 
-TEST_REGISTRY_CONTAINER ?= ghcr.io/project-zot/zot-minimal-linux-amd64:v2.0.0-rc5@sha256:740c4a4d99bf720761fd6407a227177cfeb3b1c0d4a230e16ceea960dc91dd11
+TEST_REGISTRY_CONTAINER ?= ghcr.io/project-zot/zot-minimal-linux-amd64:v2.0.0-rc6@sha256:bf95a94849cd9c6f596fb10e5a2d03b74267e7886d1ba0b3dab33337d9e46e5c
 registry-ci:
 	docker rm -f oci-conformance && \
 		echo '{"distSpecVersion":"1.1.0-dev","storage":{"rootDirectory":"/tmp/zot","gc":false,"dedupe":false},"http":{"address":"0.0.0.0","port":"5000"},"log":{"level":"debug"}}' > $(shell pwd)/$(OUTPUT_DIRNAME)/zot-config.json

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -323,7 +323,7 @@ var test03ContentDiscovery = func() {
 				// also check resp header "OCI-Filters-Applied: artifactType" denoting that an artifactType filter was applied
 				if resp.Header().Get("OCI-Filters-Applied") != "" {
 					Expect(len(index.Manifests)).To(Equal(2))
-					Expect(resp.Header().Get("OCI-Filters-Applied")).To(Equal(testRefArtifactTypeA))
+					Expect(resp.Header().Get("OCI-Filters-Applied")).To(Equal(artifactTypeFilter))
 				} else {
 					Expect(len(index.Manifests)).To(Equal(4))
 					Warn("filtering by artifact-type is not implemented")

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -91,6 +91,9 @@ const (
 	layerBase64String = "H4sIAAAAAAAAA+3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0" +
 		"WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd+qD" +
 		"jMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA"
+
+	// filter types
+	artifactTypeFilter = "artifactType"
 )
 
 var (


### PR DESCRIPTION
Per spec, the filter type (in this case "artifactType") should be returned instead of the actual filter values.

Fixes https://github.com/opencontainers/distribution-spec/issues/448