### PR TITLE
Do not panic conformance when last request fails

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -41,6 +41,7 @@ var test02Push = func() {
 
 			g.Specify("PUT request to session URL with digest should yield 201 response", func() {
 				SkipIfDisabled(push)
+				Expect(lastResponse).ToNot(BeNil())
 				req := client.NewRequest(reggie.PUT, lastResponse.GetRelativeLocation()).
 					SetQueryParam("digest", testBlobADigest).
 					SetHeader("Content-Type", "application/octet-stream").
@@ -83,6 +84,7 @@ var test02Push = func() {
 
 			g.Specify("GET request to blob URL from prior request should yield 200 or 404 based on response code", func() {
 				SkipIfDisabled(push)
+				Expect(lastResponse).ToNot(BeNil())
 				req := client.NewRequest(reggie.GET, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configs[1].Digest))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())


### PR DESCRIPTION
There are a couple of panics in the conformance test if the registry does not pass the previous test and set `lastResponse`.