### PR TITLE
Correct `last` query parameter type in API endpoints

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -739,7 +739,7 @@ This endpoint MAY be used for authentication/authorization purposes, but this is
 | end-6   | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`         | `201`       | `404`/`400`       |
 | end-7   | `PUT`          | `/v2/<name>/manifests/<reference>`                             | `201`       | `404`             |
 | end-8a  | `GET`          | `/v2/<name>/tags/list`                                         | `200`       | `404`             |
-| end-8b  | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`              | `200`       | `404`             |
+| end-8b  | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<tagname>`              | `200`       | `404`             |
 | end-9   | `DELETE`       | `/v2/<name>/manifests/<reference>`                             | `202`       | `404`/`400`/`405` |
 | end-10  | `DELETE`       | `/v2/<name>/blobs/<digest>`                                    | `202`       | `404`/`405`       |
 | end-11  | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_name>`   | `201`       | `404`             |


### PR DESCRIPTION
Incorrectly specified as integer in the endpoints summary.

> The `last` query parameter provides further means for limiting the number of tags.
> It is usually used in combination with the `n` parameter: `/v2/<name>/tags/list?n=<int>&last=<tagname>`
> 
> `<name>` is the namespace of the repository, `<int>` is the number of tags requested, and `<tagname>` is the *value* of the last tag.
> `<tagname>` MUST NOT be a numerical index, but rather it MUST be a proper tag.