### PR TITLE
conformance: pull tests shouldn't rely on tag listing

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -72,7 +72,7 @@ var test01Pull = func() {
 			g.Specify("Populate registry with test manifest", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIf(runPullSetup)
-				tag := testTagName
+				tag = testTagName
 				req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
 					reggie.WithReference(tag)).
 					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
@@ -98,26 +98,13 @@ var test01Pull = func() {
 					BeNumerically("<", 300)))
 			})
 
-			g.Specify("Get the name of a tag", func() {
-				SkipIfDisabled(pull)
-				RunOnlyIf(runPullSetup)
-				req := client.NewRequest(reggie.GET, "/v2/<name>/tags/list")
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				tag = getTagNameFromResponse(resp)
-
-				// attempt to forcibly overwrite this tag with the unique manifest for this run
-				req = client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
-					reggie.WithReference(tag)).
-					SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
-					SetBody(manifests[0].Content)
-				_, _ = client.Do(req)
-			})
-
 			g.Specify("Get tag name from environment", func() {
 				SkipIfDisabled(pull)
 				RunOnlyIfNot(runPullSetup)
-				tag = os.Getenv(envVarTagName)
+				tmp := os.Getenv(envVarTagName)
+				if tmp != "" {
+					tag = tmp
+				}
 			})
 		})
 

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -566,19 +566,6 @@ func getTagList(resp *reggie.Response) []string {
 	return tagList.Tags
 }
 
-func getTagNameFromResponse(lastResponse *reggie.Response) (tagName string) {
-	tl := &TagList{}
-	if lastResponse != nil {
-		jsonData := lastResponse.Body()
-		err := json.Unmarshal(jsonData, tl)
-		if err == nil && len(tl.Tags) > 0 {
-			tagName = tl.Tags[0]
-		}
-	}
-
-	return
-}
-
 // Adapted from https://gist.github.com/dopey/c69559607800d2f2f90b1b1ed4e550fb
 func randomString(n int) string {
 	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"


### PR DESCRIPTION
I don't have a fully-implemented container registry yet. I am implementing
endpoints incrementally in order to work toward a fully-functioning
implementation of the spec. This PR removes call to the tag listing endpoint
that was erroneously being relied on to determine the name of a valid tag to
pull.

Instead, I replaced a `tag := ...` with a `tag = ...` in an earlier ginkgo case
in order to set the outer scopoed `tag` variable used in subsequent tagged
manifest HEAD call. I suspect the tag listing endpoint was added here to
address this apparent `:=` vs `=` bug.
