### PR TITLE
spec: PUT /v2/<name>/manifests/<reference> MUST include Content-Type

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -441,7 +441,7 @@ This indicates that the upload session has begun and that the client MAY proceed
 
 To push a manifest, perform a `PUT` request to a path in the following format, and with the following headers and body: `/v2/<name>/manifests/<reference>` <sup>[end-7](#endpoints)</sup>
 
-Clients SHOULD set the `Content-Type` header to the type of the manifest being pushed.
+Clients MUST set the `Content-Type` header to the type of the manifest being pushed.
 All manifests SHOULD include a `mediaType` field declaring the type of the manifest being pushed.
 If a manifest includes a `mediaType` field, clients MUST set the `Content-Type` header to the value specified by the `mediaType` field.
 


### PR DESCRIPTION
This came up in discussion on the CNCF slack's #distribution channel:

* https://cloud-native.slack.com/archives/C01GVR8SY4R/p1696165659527899?thread_ts=1696017119.330229&cid=C01GVR8SY4R

The basic issue is that there is an ambiguity in the spec as-written where it's
not clear what the behavior should be if neither the manifest includes a
`mediaType` field (since that is optional) nor the PUT request includes a
`content-type` header.

With this change from `SHOULD` to `MUST` it's clearer that registries should
return an error if there is no `Content-Type` header.

If there are registries out there that don't enforce this and consequently
there are potential clients that don't include it already then it shouldn't be
difficult for those clients to issue a bug fix if they really need to be used
to push to a more strict registry.
