### PR TITLE
conformance: don't require http 202 for already-deleted manifest blob

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -421,6 +421,7 @@ var test02Push = func() {
 						BeNumerically("<", 300),
 					),
 					Equal(http.StatusMethodNotAllowed),
+					Equal(http.StatusNotFound),
 				))
 			})
 

--- a/conformance/04_management_test.go
+++ b/conformance/04_management_test.go
@@ -153,7 +153,10 @@ var test04ContentManagement = func() {
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
+				Expect(resp.StatusCode()).To(SatisfyAny(
+					Equal(http.StatusAccepted),
+					Equal(http.StatusNotFound),
+        ))
 			})
 
 			g.Specify("GET request to deleted blob URL should yield 404 response", func() {


### PR DESCRIPTION
In my registry implementation a `DELETE /v2/<name>/manifests/<reference>`
request deletes the manifest blob.

In the conformance tests the `DELETE /v2/<name>/manifests/<reference>` calls
are followed by `DELETE /v2/<name>/blobs/<digest>` where `<digest>` refers to
the digest of the manifest referred to by `<reference>`.

I understand why the tests are written this way - most registries seem to be
implemented in a way that it's not necessarily safe to automatically delete a
blob just because the last thing to reference it was also deleted, but my
implementation is based on storing relational metadata in an ACID-compliant DB
in such a way that bulk data is the only thing stored in the backing object
store (which for data race protection reasons isn't even keyed by content
digest but randomly-assigned UUID). Because of this design choice, it is safe
to at least attempt deleting blobs themselves when the manifest is deleted.

So because it is possible to safely delete the manifest blob during the `DELETE
/v2/<name>/manifests/<reference>` calls, the subsequent attempt to explicitly
delete the blob in the test case should allow a 404 response.
