### PR TITLE
fix discovery teardown

### DIFF
--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -355,6 +355,7 @@ var test03ContentDiscovery = func() {
 					references := []string{
 						refsIndexArtifactDigest,
 						manifests[2].Digest,
+						manifests[4].Digest,
 						refsManifestAConfigArtifactDigest,
 						refsManifestALayerArtifactDigest,
 						testTagName,

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -417,7 +417,6 @@ var test03ContentDiscovery = func() {
 						manifests[2].Digest,
 						manifests[4].Digest,
 						refsManifestAConfigArtifactDigest,
-						refsManifestAConfigArtifactDigest,
 						refsManifestALayerArtifactDigest,
 						testTagName,
 						refsManifestBConfigArtifactDigest,

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -415,6 +415,7 @@ var test03ContentDiscovery = func() {
 					references := []string{
 						refsIndexArtifactDigest,
 						manifests[2].Digest,
+						manifests[4].Digest,
 						refsManifestAConfigArtifactDigest,
 						refsManifestAConfigArtifactDigest,
 						refsManifestALayerArtifactDigest,

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -352,16 +352,29 @@ var test03ContentDiscovery = func() {
 				g.Specify("Delete created manifest & associated tags", func() {
 					SkipIfDisabled(contentDiscovery)
 					RunOnlyIf(runContentDiscoverySetup)
-					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifests[2].Digest))
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAny(
-						SatisfyAll(
-							BeNumerically(">=", 200),
-							BeNumerically("<", 300),
-						),
-						Equal(http.StatusMethodNotAllowed),
-					))
+					references := []string{
+						refsIndexArtifactDigest,
+						manifests[2].Digest,
+						refsManifestAConfigArtifactDigest,
+						refsManifestAConfigArtifactDigest,
+						refsManifestALayerArtifactDigest,
+						testTagName,
+						refsManifestBConfigArtifactDigest,
+						refsManifestBLayerArtifactDigest,
+					}
+					for _, ref := range references {
+						req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(ref))
+						resp, err := client.Do(req)
+						Expect(err).To(BeNil())
+						Expect(resp.StatusCode()).To(SatisfyAny(
+							SatisfyAll(
+								BeNumerically(">=", 200),
+								BeNumerically("<", 300),
+							),
+							Equal(http.StatusMethodNotAllowed),
+							Equal(http.StatusNotFound),
+						))
+					}
 				})
 			}
 
@@ -399,16 +412,29 @@ var test03ContentDiscovery = func() {
 				g.Specify("Delete created manifest & associated tags", func() {
 					SkipIfDisabled(contentDiscovery)
 					RunOnlyIf(runContentDiscoverySetup)
-					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifests[2].Digest))
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAny(
-						SatisfyAll(
-							BeNumerically(">=", 200),
-							BeNumerically("<", 300),
-						),
-						Equal(http.StatusMethodNotAllowed),
-					))
+					references := []string{
+						refsIndexArtifactDigest,
+						manifests[2].Digest,
+						refsManifestAConfigArtifactDigest,
+						refsManifestAConfigArtifactDigest,
+						refsManifestALayerArtifactDigest,
+						testTagName,
+						refsManifestBConfigArtifactDigest,
+						refsManifestBLayerArtifactDigest,
+					}
+					for _, ref := range references {
+						req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(ref))
+						resp, err := client.Do(req)
+						Expect(err).To(BeNil())
+						Expect(resp.StatusCode()).To(SatisfyAny(
+							SatisfyAll(
+								BeNumerically(">=", 200),
+								BeNumerically("<", 300),
+							),
+							Equal(http.StatusMethodNotAllowed),
+							Equal(http.StatusNotFound),
+						))
+					}
 				})
 			}
 
@@ -425,6 +451,7 @@ var test03ContentDiscovery = func() {
 							BeNumerically("<", 300),
 						),
 						Equal(http.StatusMethodNotAllowed),
+						Equal(http.StatusNotFound),
 					))
 				}
 

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -356,7 +356,6 @@ var test03ContentDiscovery = func() {
 						refsIndexArtifactDigest,
 						manifests[2].Digest,
 						refsManifestAConfigArtifactDigest,
-						refsManifestAConfigArtifactDigest,
 						refsManifestALayerArtifactDigest,
 						testTagName,
 						refsManifestBConfigArtifactDigest,

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -247,6 +247,7 @@ var test03ContentDiscovery = func() {
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				tagList = getTagList(resp)
 				numTags = len(tagList)
 			})
 


### PR DESCRIPTION
Discovery test teardown was broken prior to this because it would attempt to
delete a blob before deleting at least five manifests left over from the setup
that still reference it. Most registries probably don't care about deleting
content that's referenced by other content, which is probably why this works
for others.

Also, I was seeing `GET /v2/<name>/tags/list?n=0` requests and then out of
bounds indexing into the resulting slice because of the weird logic used to
calculate what the `n` parameter should be in the tag listing endpoint tests.

Fixes #457.
