### PR TITLE
clarify where OCI-Chunk-Min-Length response headers are expected

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -319,7 +319,7 @@ The process remains unchanged for chunked upload, except that the post request M
 Content-Length: 0
 ```
 
-If the registry has a minimum chunk size, the response SHOULD include the following header, where `<size>` is the size in bytes (see the blob `PATCH` definition for usage):
+If the registry has a minimum chunk size, the `POST` response SHOULD include the following header, where `<size>` is the size in bytes (see the blob `PATCH` definition for usage):
 
 ```
 OCI-Chunk-Min-Length: <size>
@@ -351,7 +351,7 @@ It MUST match the following regular expression:
 ```
 
 The `<length>` is the content-length, in bytes, of the current chunk.
-If the registry provides a `OCI-Chunk-Min-Length` header in the `PUT` response, the size of each chunk, except for the final chunk, SHOULD be greater or equal to that value.
+If the registry provides an `OCI-Chunk-Min-Length` header in the `POST` response, the size of each chunk, except for the final chunk, SHOULD be greater or equal to that value.
 The final chunk MAY have any length.
 
 Each successful chunk upload MUST have a `202 Accepted` response code, and MUST have the following headers:


### PR DESCRIPTION
(see commit message)

