### PR TITLE
spec: HEAD blob response should include content-length header

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -198,6 +198,7 @@ In order to verify that a repository contains a given manifest or blob, make a `
 
 A HEAD request to an existing blob or manifest URL MUST return `200 OK`.
 A successful response SHOULD contain the digest of the uploaded blob in the header `Docker-Content-Digest`.
+A successful response SHOULD contain the size in bytes of the uploaded blob in the header `Content-Length`.
 
 If the blob or manifest is not found in the registry, the response code MUST be `404 Not Found`.
 


### PR DESCRIPTION
My distribution implementation recently began passing all conformance tests, so I began testing my registry by pushing images using docker. My registry implementation happens to strictly adhere to the OCI image spec in terms of required fields, including on [the OCI descriptor](https://github.com/opencontainers/image-spec/blob/main/descriptor.md).

So when docker tried pushing image manifests without the `size` field in the config descriptor, my registry returned a `MANIFEST_INVALID` error in its response.

I submitted a couple issues to moby:

* https://github.com/moby/moby/issues/46641
* https://github.com/moby/buildkit/issues/4328

And after digging in for a while, I figured out what was going on.

Just before pushing a manifest docker issues a `HEAD PUT /v2/<repository>/blobs/<digest>` request for the manifest config blob and seems to use the `content-length` header in the response to that request to set the config descriptor size field.

If there is no `content-length` header in the response, the field presumably gets set to 0. In combination with the [`omitempty` tag](https://github.com/distribution/distribution/blob/main/blobs.go#L71) on the Descriptor type's size field and the fact that whatever json marshalling library is being used considers 0 to be empty/unset, when docker serializes the Descriptor struct it omits the size field entirely.

As weird as it is for me to say this given how much time I wasted on this, I think the `omitempty` behavior is right for the `Descriptor` type, otherwise my registry would have unknowingly accepted manifests with incorrectly 0-valued descriptor size fields. It wouldn't help registries implemented in weaker-typed languages to remove the `omitempty` because those languages lack the ability to effectively express the difference between optional and required values anyway (not impossible, just harder to do than in a strongly-typed language).

So because there is a major distribution client with this behavior I am proposing that we update the spec to suggest that it's a good idea to set the `content-length` field. I might even go as far as to say it should be a `MUST` rather than a `SHOULD`, but I suspect folks might balk at that.
