### PR TITLE
Conformance: test for annotation pull up

### DIFF
--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -316,6 +316,10 @@ var test03ContentDiscovery = func() {
 				Expect(err).To(BeNil())
 				Expect(len(index.Manifests)).To(Equal(5))
 				Expect(index.Manifests[0].Digest).ToNot(Equal(index.Manifests[1].Digest))
+				for i := 0; i < len(index.Manifests); i++ {
+					Expect(len(index.Manifests[i].Annotations)).To(Equal(1))
+					Expect(index.Manifests[i].Annotations[testAnnotationKey]).To(Equal(testAnnotationValues[index.Manifests[i].Digest.String()]))
+				}
 			})
 
 			g.Specify("GET request to existing blob with filter should yield 200", func() {
@@ -339,8 +343,16 @@ var test03ContentDiscovery = func() {
 				if resp.Header().Get("OCI-Filters-Applied") != "" {
 					Expect(len(index.Manifests)).To(Equal(2))
 					Expect(resp.Header().Get("OCI-Filters-Applied")).To(Equal(artifactTypeFilter))
+					for i := 0; i < len(index.Manifests); i++ {
+						Expect(len(index.Manifests[i].Annotations)).To(Equal(1))
+						Expect(index.Manifests[i].Annotations[testAnnotationKey]).To(Equal(testAnnotationValues[index.Manifests[i].Digest.String()]))
+					}
 				} else {
 					Expect(len(index.Manifests)).To(Equal(5))
+					for i := 0; i < len(index.Manifests); i++ {
+						Expect(len(index.Manifests[i].Annotations)).To(Equal(1))
+						Expect(index.Manifests[i].Annotations[testAnnotationKey]).To(Equal(testAnnotationValues[index.Manifests[i].Digest.String()]))
+					}
 					Warn("filtering by artifact-type is not implemented")
 				}
 			})

--- a/conformance/image.go
+++ b/conformance/image.go
@@ -47,13 +47,49 @@ type descriptor struct {
 	// Size specifies the size in bytes of the blob.
 	Size int64 `json:"size"`
 
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Data specifies the data of the object described by the descriptor.
 	Data []byte `json:"data,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *platform `json:"platform,omitempty"`
+
+	// ArtifactType is the IANA media type of this artifact.
+	ArtifactType string `json:"artifactType,omitempty"`
 
 	// NewUnspecifiedField is not covered by image-spec.
 	// Registry implementations should still successfully store and serve
 	// manifests containing this data.
 	NewUnspecifiedField []byte `json:"newUnspecifiedField"`
+}
+
+// platform describes the platform which the image in the manifest runs on.
+type platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64le`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `v7` to specify ARMv7 when architecture is `arm`.
+	Variant string `json:"variant,omitempty"`
 }
 
 // rootFS describes a layer content addresses

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -126,6 +126,8 @@ var (
 	testBlobBChunk2Length              string
 	testBlobBChunk1Range               string
 	testBlobBChunk2Range               string
+	testAnnotationKey                  string
+	testAnnotationValues               map[string]string
 	client                             *reggie.Client
 	crossmountNamespace                string
 	dummyDigest                        string
@@ -336,6 +338,9 @@ func init() {
 
 	testRefArtifactTypeB = "application/vnd.nba.strawberry.jam.croissant"
 
+	testAnnotationKey = "org.opencontainers.conformance.test"
+	testAnnotationValues = map[string]string{}
+
 	// artifact with Subject ref using config.MediaType = artifactType
 	refsManifestAConfigArtifact := manifest{
 		SchemaVersion: 2,
@@ -353,6 +358,9 @@ func init() {
 		Layers: []descriptor{
 			emptyJSONDescriptor,
 		},
+		Annotations: map[string]string{
+			testAnnotationKey: "test config a",
+		},
 	}
 
 	refsManifestAConfigArtifactContent, err = json.MarshalIndent(&refsManifestAConfigArtifact, "", "\t")
@@ -361,6 +369,7 @@ func init() {
 	}
 
 	refsManifestAConfigArtifactDigest = godigest.FromBytes(refsManifestAConfigArtifactContent).String()
+	testAnnotationValues[refsManifestAConfigArtifactDigest] = refsManifestAConfigArtifact.Annotations[testAnnotationKey]
 
 	refsManifestBConfigArtifact := manifest{
 		SchemaVersion: 2,
@@ -378,6 +387,9 @@ func init() {
 		Layers: []descriptor{
 			emptyJSONDescriptor,
 		},
+		Annotations: map[string]string{
+			testAnnotationKey: "test config b",
+		},
 	}
 
 	refsManifestBConfigArtifactContent, err = json.MarshalIndent(&refsManifestBConfigArtifact, "", "\t")
@@ -386,6 +398,7 @@ func init() {
 	}
 
 	refsManifestBConfigArtifactDigest = godigest.FromBytes(refsManifestBConfigArtifactContent).String()
+	testAnnotationValues[refsManifestBConfigArtifactDigest] = refsManifestBConfigArtifact.Annotations[testAnnotationKey]
 
 	// artifact with Subject ref using ArtifactType, config.MediaType = emptyJSON
 	refsManifestALayerArtifact := manifest{
@@ -405,6 +418,9 @@ func init() {
 				Digest:    godigest.FromBytes(testRefBlobA),
 			},
 		},
+		Annotations: map[string]string{
+			testAnnotationKey: "test layer a",
+		},
 	}
 
 	refsManifestALayerArtifactContent, err = json.MarshalIndent(&refsManifestALayerArtifact, "", "\t")
@@ -413,6 +429,7 @@ func init() {
 	}
 
 	refsManifestALayerArtifactDigest = godigest.FromBytes(refsManifestALayerArtifactContent).String()
+	testAnnotationValues[refsManifestALayerArtifactDigest] = refsManifestALayerArtifact.Annotations[testAnnotationKey]
 
 	refsManifestBLayerArtifact := manifest{
 		SchemaVersion: 2,
@@ -431,6 +448,9 @@ func init() {
 				Digest:    godigest.FromBytes(testRefBlobB),
 			},
 		},
+		Annotations: map[string]string{
+			testAnnotationKey: "test layer b",
+		},
 	}
 
 	refsManifestBLayerArtifactContent, err = json.MarshalIndent(&refsManifestBLayerArtifact, "", "\t")
@@ -439,6 +459,7 @@ func init() {
 	}
 
 	refsManifestBLayerArtifactDigest = godigest.FromBytes(refsManifestBLayerArtifactContent).String()
+	testAnnotationValues[refsManifestBLayerArtifactDigest] = refsManifestBLayerArtifact.Annotations[testAnnotationKey]
 
 	testRefArtifactTypeIndex = "application/vnd.food.stand"
 	refsIndexArtifact := index{
@@ -462,12 +483,16 @@ func init() {
 			Size:      int64(len(manifests[4].Content)),
 			Digest:    godigest.FromBytes(manifests[4].Content),
 		},
+		Annotations: map[string]string{
+			testAnnotationKey: "test index",
+		},
 	}
 	refsIndexArtifactContent, err = json.MarshalIndent(&refsIndexArtifact, "", "\t")
 	if err != nil {
 		log.Fatal(err)
 	}
 	refsIndexArtifactDigest = godigest.FromBytes(refsIndexArtifactContent).String()
+	testAnnotationValues[refsIndexArtifactDigest] = refsIndexArtifact.Annotations[testAnnotationKey]
 
 	dummyDigest = godigest.FromString("hello world").String()
 


### PR DESCRIPTION
Fixes #475.

This adds tests to verify the annotations have been pulled up.