### PR TITLE
Support referrers to a missing manifest

### DIFF
--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -147,6 +147,8 @@ var (
 	refsManifestBConfigArtifactDigest  string
 	refsManifestBLayerArtifactContent  []byte
 	refsManifestBLayerArtifactDigest   string
+	refsManifestCLayerArtifactContent  []byte
+	refsManifestCLayerArtifactDigest   string
 	refsIndexArtifactContent           []byte
 	refsIndexArtifactDigest            string
 	reportJUnitFilename                string
@@ -439,6 +441,33 @@ func init() {
 	}
 
 	refsManifestBLayerArtifactDigest = godigest.FromBytes(refsManifestBLayerArtifactContent).String()
+
+	// ManifestCLayerArtifact is the same as B but based on a subject that has not been pushed
+	refsManifestCLayerArtifact := manifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.manifest.v1+json",
+		ArtifactType:  testRefArtifactTypeB,
+		Config:        emptyJSONDescriptor,
+		Subject: &descriptor{
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Size:      int64(len(manifests[3].Content)),
+			Digest:    godigest.FromBytes(manifests[3].Content),
+		},
+		Layers: []descriptor{
+			{
+				MediaType: testRefArtifactTypeB,
+				Size:      int64(len(testRefBlobB)),
+				Digest:    godigest.FromBytes(testRefBlobB),
+			},
+		},
+	}
+
+	refsManifestCLayerArtifactContent, err = json.MarshalIndent(&refsManifestCLayerArtifact, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	refsManifestCLayerArtifactDigest = godigest.FromBytes(refsManifestCLayerArtifactContent).String()
 
 	testRefArtifactTypeIndex = "application/vnd.food.stand"
 	refsIndexArtifact := index{

--- a/spec.md
+++ b/spec.md
@@ -566,8 +566,6 @@ The descriptors MUST include an `artifactType` field that is set to the value of
 If the `artifactType` is empty or missing in the image manifest, the value of `artifactType` MUST be set to the config descriptor `mediaType` value.
 The descriptors MUST include annotations from the image manifest.
 If a query results in no matching referrers, an empty manifest list MUST be returned.
-If a manifest with the digest `<digest>` does not exist, a registry MAY return an empty manifest list.
-After a manifest with the digest `<digest>` is pushed, the registry MUST include previously pushed entries in the referrers list.
 
 ```json
 {


### PR DESCRIPTION
In the discussions of whether to require registries to accept a manifest with a subject pointing to missing digest, there was  a use case mentioned of pushing metadata to a separate repo from the images. In cases where the registry does support pushing these manifests, the empty response to the referrers API breaks that use case. It also doesn't provide any value for those that want to validate the subject descriptor. So I propose removing that exception from the spec.

The changes to the conformance tests can be gated behind configuration variables if registries have the option to validate the subject field in a future version of the spec.