### PR TITLE
Conformance: remove referrers digest header check

### DIFF
--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -308,9 +308,6 @@ var test03ContentDiscovery = func() {
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 				Expect(resp.Header().Get("Content-Type")).To(Equal("application/vnd.oci.image.index.v1+json"))
-				if h := resp.Header().Get("Docker-Content-Digest"); h != "" {
-					Expect(h).To(Equal(configs[4].Digest))
-				}
 
 				var index index
 				err = json.Unmarshal(resp.Body(), &index)
@@ -328,9 +325,6 @@ var test03ContentDiscovery = func() {
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 				Expect(resp.Header().Get("Content-Type")).To(Equal("application/vnd.oci.image.index.v1+json"))
-				if h := resp.Header().Get("Docker-Content-Digest"); h != "" {
-					Expect(h).To(Equal(configs[4].Digest))
-				}
 
 				var index index
 				err = json.Unmarshal(resp.Body(), &index)


### PR DESCRIPTION
The referrers headers don't specify the Docker-Content-Digest value, and if set, this does not appear to be the correct value. So this pulls it out of the conformance test.