### PR TITLE
spec: include optional port separator

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -153,7 +153,7 @@ To pull a manifest, perform a `GET` request to a URL in the following form:
 The `<reference>` MUST NOT be in any other format.
 Throughout this document, `<name>` MUST match the following regular expression:
 
-`[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*`
+`[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(?::[0-9]+)?(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*`
 
 Throughout this document, `<reference>` as a tag MUST be at most 128 characters in length and MUST match the following regular expression:
 


### PR DESCRIPTION
This change makes the separators consistent
with the implementation in the docker distribution [here](https://github.com/distribution/distribution/blob/97b1d649c4938d0f608d96454d6a8326b1f96acd/reference/regexp.go#L65)

Relevant part from the code:

```golang
// optionalPort matches an optional port-number including the port separator
// (e.g. ":80").
optionalPort = `(?::[0-9]+)?`
```
Fix found by: [6ax](https://github.com/6ax) [here](https://github.com/docker/docker-py/issues/3195#issuecomment-1852274337) Related: https://github.com/docker/docker-py/issues/3195