### PR TITLE
Update GitHub Actions CI packages and command

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload OCI conformance results as build artifact
         if: always() && steps.tests.outputs.has-report == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-conformance-results-${{ matrix.go }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload OCI conformance results as build artifact
         if: always() && steps.tests.outputs.has-report == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-conformance-results-${{ matrix.go }}
           path: |

--- a/.github/workflows/conformance-action-pr.yml
+++ b/.github/workflows/conformance-action-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start a test registry (zot)
         run: |
           set -x

--- a/.github/workflows/conformance-action.yml
+++ b/.github/workflows/conformance-action.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start a test registry (zot)
         run: |
           set -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         id: prepare
@@ -35,12 +35,12 @@ jobs:
             MAJOR=${MINOR%.*}
             TAGS="${TAGS},${IMAGE}:${MINOR},${IMAGE}:${MAJOR}"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Docker Login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.repository_owner == 'opencontainers'
         with:
           registry: ghcr.io
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: conformance/
           # platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x


### PR DESCRIPTION
### Issue
N/A

### Description
This change updates GitHub Actions packages actions/checkout to v4, actions/setup-go to v5, and actions/upload-artifacts to v4 to resolve NodeJS 16 deprecation warnings. It also updates GitHub Actions set-output command which is also deprecated.

### Testing
CI passes without deprecation warnings

### Additional references
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/