### PR TITLE
Update GitHub Actions matrix for Go v1.21 and v1.22

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20']
+        go: ['1.21', '1.22']
 
     steps:
       - name: checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20']
+        go: ['1.21', '1.22']
 
     steps:
       - name: checkout source code


### PR DESCRIPTION
### Issue
N/A

### Description
This change adds Go v1.21 and v1.22 to the GitHub Actions matrix in CI. It also drops previous Go versions as they would no longer receive updates.