### PR TITLE
Fix typo in `/v2/<name>/tags/list` endpoint

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -751,7 +751,7 @@ This endpoint MAY be used for authentication/authorization purposes, but this is
 | end-6   | `PUT`          | `/v2/<name>/blobs/uploads/<reference>?digest=<digest>`         | `201`       | `404`/`400`       |
 | end-7   | `PUT`          | `/v2/<name>/manifests/<reference>`                             | `201`       | `404`             |
 | end-8a  | `GET`          | `/v2/<name>/tags/list`                                         | `200`       | `404`             |
-| end-8b  | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<integer>`              | `200`       | `404`             |
+| end-8b  | `GET`          | `/v2/<name>/tags/list?n=<integer>&last=<tagname>`              | `200`       | `404`             |
 | end-9   | `DELETE`       | `/v2/<name>/manifests/<reference>`                             | `202`       | `404`/`400`/`405` |
 | end-10  | `DELETE`       | `/v2/<name>/blobs/<digest>`                                    | `202`       | `404`/`405`       |
 | end-11  | `POST`         | `/v2/<name>/blobs/uploads/?mount=<digest>&from=<other_name>`   | `201`       | `404`             |


### PR DESCRIPTION
From @scottwittenburg's comment in #470:

> Just want to note I was confused when reading this section, because in a section above it says `&last=<tagname>`, and additionally "`<tagname>` MUST NOT be a numerical index, but rather it MUST be a proper tag".

