### PR TITLE
Conformance: remove labels from junit reporter output

### DIFF
--- a/conformance/00_conformance_suite_test.go
+++ b/conformance/00_conformance_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	g "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 )
 
@@ -18,12 +19,18 @@ func TestConformance(t *testing.T) {
 
 	RegisterFailHandler(g.Fail)
 	suiteConfig, reporterConfig := g.GinkgoConfiguration()
-	reporterConfig.JUnitReport = reportJUnitFilename
 	hr := newHTMLReporter(reportHTMLFilename)
 	g.ReportAfterEach(hr.afterReport)
 	g.ReportAfterSuite("html custom reporter", func(r g.Report) {
 		if err := hr.endSuite(r); err != nil {
 			log.Printf("\nWARNING: cannot write HTML summary report: %v", err)
+		}
+	})
+	g.ReportAfterSuite("junit custom reporter", func(r g.Report) {
+		if reportJUnitFilename != "" {
+			_ = reporters.GenerateJUnitReportWithConfig(r, reportJUnitFilename, reporters.JunitReportConfig{
+				OmitLeafNodeType: true,
+			})
 		}
 	})
 	g.RunSpecs(t, "conformance tests", suiteConfig, reporterConfig)


### PR DESCRIPTION
The junit conformance reports now include labels by default that break the web site rendering. Rather than complicate the rendering with label parsers, this stops them from being included.