### PR TITLE
Add support for content range requests when getting blobs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -190,6 +190,8 @@ If present, the value of this header MUST be a digest matching that of the respo
 
 If the blob is not found in the registry, the response code MUST be `404 Not Found`.
 
+A registry SHOULD support the `Range` request header in accordance with [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-range-requests).
+
 ##### Checking if content exists in the registry
 
 In order to verify that a repository contains a given manifest or blob, make a `HEAD` request to a URL in the following form:


### PR DESCRIPTION
OCI artifacts support has landed in various OCI specs v1.1.0 which allows for arbitrary artifact types, small and large.

Large artifacts (even existing container images) pose a particular challenge that:
1.    it takes too long to download
2.   it takes too long to unpack

This PR begins to address 1. above.

The client can initiate a HEAD request to get the size and later multiple GET range requests to download a blob in parallel.

Fixes #354