### PR TITLE
Allow 404 on blob deletion in conformance tests

### DIFF
--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -298,6 +298,7 @@ var test01Pull = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})
@@ -312,6 +313,7 @@ var test01Pull = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})
@@ -327,6 +329,7 @@ var test01Pull = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -420,8 +420,8 @@ var test02Push = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
-					Equal(http.StatusMethodNotAllowed),
 					Equal(http.StatusNotFound),
+					Equal(http.StatusMethodNotAllowed),
 				))
 			})
 
@@ -436,6 +436,7 @@ var test02Push = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -405,8 +405,8 @@ var test03ContentDiscovery = func() {
 								BeNumerically(">=", 200),
 								BeNumerically("<", 300),
 							),
-							Equal(http.StatusMethodNotAllowed),
 							Equal(http.StatusNotFound),
+							Equal(http.StatusMethodNotAllowed),
 						))
 					}
 				})
@@ -423,6 +423,7 @@ var test03ContentDiscovery = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})
@@ -438,6 +439,7 @@ var test03ContentDiscovery = func() {
 						BeNumerically(">=", 200),
 						BeNumerically("<", 300),
 					),
+					Equal(http.StatusNotFound),
 					Equal(http.StatusMethodNotAllowed),
 				))
 			})
@@ -484,8 +486,8 @@ var test03ContentDiscovery = func() {
 							BeNumerically(">=", 200),
 							BeNumerically("<", 300),
 						),
-						Equal(http.StatusMethodNotAllowed),
 						Equal(http.StatusNotFound),
+						Equal(http.StatusMethodNotAllowed),
 					))
 				}
 


### PR DESCRIPTION
Fixes #540.

This allows a 404 on blob deletion for registries that immediately prune blobs on manifest deletion. It also reorders a couple of checks for consistency (404 before 405).