### PR TITLE
Update GHA uses

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload OCI conformance results as build artifact
         if: always() && steps.tests.outputs.has-report == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-conformance-results-${{ matrix.go }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload OCI conformance results as build artifact
         if: always() && steps.tests.outputs.has-report == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-conformance-results-${{ matrix.go }}
           path: |

--- a/.github/workflows/conformance-action-pr.yml
+++ b/.github/workflows/conformance-action-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start a test registry (zot)
         run: |
           set -x

--- a/.github/workflows/conformance-action.yml
+++ b/.github/workflows/conformance-action.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start a test registry (zot)
         run: |
           set -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         id: prepare
@@ -35,12 +35,12 @@ jobs:
             MAJOR=${MINOR%.*}
             TAGS="${TAGS},${IMAGE}:${MINOR},${IMAGE}:${MAJOR}"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >>$GITHUB_OUTPUT
+          echo "tags=${TAGS}" >>$GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >>$GITHUB_OUTPUT
 
       - name: Docker Login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.repository_owner == 'opencontainers'
         with:
           registry: ghcr.io
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: conformance/
           # platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Upload OCI distribution-spec conformance results as build artifact
       if: always() && steps.run-conformance.outputs.has-report == 'true'
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: oci-distribution-spec-conformance-results-${{ steps.build-conformance.outputs.conformance-version }}
         path: |


### PR DESCRIPTION
We have a lot of stale actions. This bumps everything to the latest release.

- actions/checkout v3 -> v4
- actions/setup-go v3 -> v5
- docker/login-action v2 -> v3
- actions/upload-artifact v3 -> v4
- Replace deprecated `set-output` with `$GITHUB_OUTPUT` file

Replaces #510 