### PR TITLE
Release v1.1.1

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -22,10 +22,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "+dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## Mailing list

This thread tracks the release votes: https://groups.google.com/a/opencontainers.org/g/dev/c/wOQiNKY4fUQ

## Tag

This would mean tagging a139cc423184af6078077b9b7ee336eddbd03f8f as v1.1.1

## Changes

dbdff9f Correct `last` query parameter type in API endpoints (#464)
3ee02f0 Fix order in spec TOC (#471)
c758964 conformance: pull tests shouldn't rely on tag listing (#476)
6927392 build(deps): bump golang.org/x/net from 0.11.0 to 0.17.0 in /conformance (#480)
6152da4 version: bump back to +dev (507)
337e1ec Make the conformance test names unique (#509)
1d42d75 Update GitHub Actions matrix for Go v1.21 and v1.22 (#511)
d6bcd99 Teardown manifests by digests (#525)
36cd91d MAINTAINERS: move vbatts to EMERITUS (#526)
631b369 fix: allow 404 on tag list for virtual repositories (#528)
4d091a9 Fix redaction of conformance tests (#529)
a6971cc CODEOWNERS: remove vbatts (#526)
33f0657 chore: apply strict equal comparison (#528)
aa83cb4 Conformance: remove labels from junit reporter output (#524)
37a73f4 Tag pagination (#470)
adf534a build(deps): bump golang.org/x/net from 0.17.0 to 0.23.0 in /conformance (#535)
9d4c4a9 Add support for content range requests when getting blobs (#537)
47008ca Allow 404 on blob deletion in conformance tests (#541)
c496de1 Define a repository and fix usage of the term (#325)
7d412fc Add note on repository name length limit (#542)
bc5843c fix: nit in referrers filtering (#544)
e3abeed Clarify tags and deletion of manifests (#552)
82954d9 Add step to update website after a release (#460)
1a6e7d3 Align endpoint status with rest of spec (#555)
24084d4 Explicitly recommend content digest information (#556)
aae3b8e Update golang.org/x/net to v0.33.0 (#558)
f1a874a Update GHA uses (#560)
a139cc4 version: release v1.1.1

## Diff

https://github.com/opencontainers/distribution-spec/compare/v1.1.0...main

## Votes

- [x] @dmcgowan
- [x] @jzelinskie
- [ ] @jonjohnsonjr
- [x] @jdolitsky
- [x] @mikebrow
- [ ] @stevvooe
- [x] @sudo-bmitch
