### PR TITLE
fix: add required Content-Range header to PATCH test

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -30,8 +30,12 @@ var test02Push = func() {
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
 
+				length, _ := strconv.Atoi(testBlobALength)
+
 				req = client.NewRequest(reggie.PATCH, resp.GetRelativeLocation()).
 					SetHeader("Content-Type", "application/octet-stream").
+					SetHeader("Content-Length", testBlobALength).
+					SetHeader("Content-Range", fmt.Sprintf("0-%d", length-1)).
 					SetBody(testBlobA)
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
@@ -217,7 +221,8 @@ var test02Push = func() {
 
 			g.Specify("Get on stale blob upload should return 204 with a range and location", func() {
 				SkipIfDisabled(push)
-				req := client.NewRequest(reggie.GET, prevResponse.GetRelativeLocation())
+				req := client.
+					NewRequest(reggie.GET, prevResponse.GetRelativeLocation())
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusNoContent))


### PR DESCRIPTION
The spec requires Content-Range header for PATCH requests, but the conformance test "PATCH request with blob in body should yield 202 response" omits this requirement. This creates a mismatch between the spec and the test suite.

The spec clearly states that for PATCH requests:
- Content-Range is required
- Must be inclusive on both ends
- First chunk must begin with 0
- Must match regex ^[0-9]+-[0-9]+$

This fix adds the required Content-Range header to the test, ensuring it properly validates spec compliance.

I implemented this a little hacky to illustrate, I wanted to make sure I wasn't misinterpreting the spec, but when I enforced the content-range header on PATCH in our [registry](https://github.com/massdriver-cloud/oci), it caused the conformance test suite to fail.

Happy to move stuff into setup.go if you want it to be inline with the other setup variables. I didn't do it there since its not a "chunk" and that appears to be the naming convention. Anywho, thanks!