### PR TITLE
Fix `last` pagination conformance test

### DIFF
--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -272,7 +272,6 @@ var test03ContentDiscovery = func() {
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 				tagList = getTagList(resp)
-				Expect(err).To(BeNil())
 				Expect(len(tagList)).To(Equal(numResults))
 			})
 
@@ -283,16 +282,18 @@ var test03ContentDiscovery = func() {
 					SetQueryParam("n", strconv.Itoa(numResults))
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
+				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 				tagList = getTagList(resp)
+				last := tagList[numResults-1]
 				req = client.NewRequest(reggie.GET, "/v2/<name>/tags/list").
 					SetQueryParam("n", strconv.Itoa(numResults)).
 					SetQueryParam("last", tagList[numResults-1])
 				resp, err = client.Do(req)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
-				Expect(err).To(BeNil())
+				tagList = getTagList(resp)
 				Expect(len(tagList)).To(BeNumerically("<=", numResults))
-				Expect(tagList).To(ContainElement(tagList[numResults-1]))
+				Expect(tagList).ToNot(ContainElement(last))
 			})
 		})
 


### PR DESCRIPTION
It wasn't testing that the actual result does not contain the parameter, which is what the spec mandates:

> A request of this sort will return up to `<int>` tags, beginning non-inclusively with `<tagname>`. That is to say, `<tagname>` will not be included in the results, but up to `<int>` tags *after* `<tagname>` will be returned.

Also, this removes a couple duplicated/useless `Expect(err).To(BeNil())` invocations.