### PR TITLE
Improve licensing of tests source code

### DIFF
--- a/conformance/00_conformance_suite_test.go
+++ b/conformance/00_conformance_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/01_pull_test.go
+++ b/conformance/01_pull_test.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/04_management_test.go
+++ b/conformance/04_management_test.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/Dockerfile
+++ b/conformance/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright contributors to the Open Containers Distribution Specification
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # ---
 # Stage 1: Install certs and build conformance binary
 # ---

--- a/conformance/image.go
+++ b/conformance/image.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/reporter.go
+++ b/conformance/reporter.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -1,3 +1,17 @@
+// Copyright contributors to the Open Containers Distribution Specification
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conformance
 
 import (


### PR DESCRIPTION
The source code files for the conformance tests don’t provide the typical Apache v2.0 licensing headers. The copyright holders are not explicitly listed either. It would make sense to have them for clearer licensing, simplifying contributions and reuse.

This PR adds the licensing headers provided by the Apache v2.0 license itself. It should also add the corresponding copyright holders.

This information should also help ensuring that the license information does not get lost, if someone comes to the idea of only copying the directory with the conformance tests.

Disclaimer: I am not a lawyer.