### PR TITLE
Improve manifests cleanup

### DIFF
--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -29,7 +29,7 @@ var test02Push = func() {
 	g.Context(titlePush, func() {
 
 		var lastResponse, prevResponse *reggie.Response
-		var emptyLayerManifestRef string
+		var manifestRefs []string
 
 		g.Context("Setup", func() {
 			// No setup required at this time for push tests
@@ -354,15 +354,14 @@ var test02Push = func() {
 				SkipIfDisabled(push)
 				for i := 0; i < 4; i++ {
 					tag := fmt.Sprintf("test%d", i)
-					req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
-						reggie.WithReference(tag)).
-						SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
-						SetBody(manifests[1].Content)
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					location := resp.Header().Get("Location")
-					Expect(location).ToNot(BeEmpty())
-					Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+					manifestRefs = pushManifest(
+						&ManifestInfo{
+							Tag:     tag,
+							Digest:  manifests[1].Digest,
+							Content: manifests[1].Content,
+						},
+						manifestRefs, g.GinkgoT(),
+					)
 				}
 			})
 
@@ -376,9 +375,10 @@ var test02Push = func() {
 				Expect(err).To(BeNil())
 				if resp.StatusCode() == http.StatusCreated {
 					location := resp.Header().Get("Location")
-					emptyLayerManifestRef = location
 					Expect(location).ToNot(BeEmpty())
 					Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+					manifestRefs = append(manifestRefs, emptyLayerTestTag)
+					manifestRefs = append(manifestRefs, emptyLayerManifestDigest)
 				} else {
 					Warn("image manifest with no layers is not supported")
 				}
@@ -399,28 +399,7 @@ var test02Push = func() {
 				g.Specify("Delete manifest created in tests", func() {
 					SkipIfDisabled(push)
 					RunOnlyIf(runPushSetup)
-					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifests[1].Digest))
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAny(
-						SatisfyAll(
-							BeNumerically(">=", 200),
-							BeNumerically("<", 300),
-						),
-						Equal(http.StatusMethodNotAllowed),
-					))
-					if emptyLayerManifestRef != "" {
-						req = client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>", reggie.WithReference(emptyLayerManifestDigest))
-						resp, err = client.Do(req)
-						Expect(err).To(BeNil())
-						Expect(resp.StatusCode()).To(SatisfyAny(
-							SatisfyAll(
-								BeNumerically(">=", 200),
-								BeNumerically("<", 300),
-							),
-							Equal(http.StatusMethodNotAllowed),
-						))
-					}
+					deleteManifests(manifestRefs, g.GinkgoT())
 				})
 			}
 
@@ -460,28 +439,7 @@ var test02Push = func() {
 				g.Specify("Delete manifest created in tests", func() {
 					SkipIfDisabled(push)
 					RunOnlyIf(runPushSetup)
-					req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<digest>", reggie.WithDigest(manifests[1].Digest))
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAny(
-						SatisfyAll(
-							BeNumerically(">=", 200),
-							BeNumerically("<", 300),
-						),
-						Equal(http.StatusMethodNotAllowed),
-					))
-					if emptyLayerManifestRef != "" {
-						req = client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>", reggie.WithReference(emptyLayerManifestDigest))
-						resp, err = client.Do(req)
-						Expect(err).To(BeNil())
-						Expect(resp.StatusCode()).To(SatisfyAny(
-							SatisfyAll(
-								BeNumerically(">=", 200),
-								BeNumerically("<", 300),
-							),
-							Equal(http.StatusMethodNotAllowed),
-						))
-					}
+					deleteManifests(manifestRefs, g.GinkgoT())
 				})
 			}
 		})

--- a/conformance/02_push_test.go
+++ b/conformance/02_push_test.go
@@ -29,6 +29,7 @@ var test02Push = func() {
 	g.Context(titlePush, func() {
 
 		var lastResponse, prevResponse *reggie.Response
+		var blobRefs []string
 		var manifestRefs []string
 
 		g.Context("Setup", func() {
@@ -65,6 +66,7 @@ var test02Push = func() {
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
+				blobRefs = append(blobRefs, testBlobADigest)
 			})
 		})
 
@@ -93,6 +95,7 @@ var test02Push = func() {
 					Equal(http.StatusCreated),
 					Equal(http.StatusAccepted),
 				))
+				blobRefs = append(blobRefs, configs[1].Digest)
 				lastResponse = resp
 			})
 
@@ -130,6 +133,7 @@ var test02Push = func() {
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				blobRefs = append(blobRefs, configs[1].Digest)
 			})
 
 			g.Specify("GET request to existing blob should yield 200 response", func() {
@@ -155,6 +159,7 @@ var test02Push = func() {
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				blobRefs = append(blobRefs, layerBlobDigest)
 			})
 
 			g.Specify("GET request to existing layer should yield 200 response", func() {
@@ -267,33 +272,20 @@ var test02Push = func() {
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 				location := resp.Header().Get("Location")
 				Expect(location).ToNot(BeEmpty())
+				blobRefs = append(blobRefs, testBlobBDigest)
 			})
 		})
 
 		g.Context("Cross-Repository Blob Mount", func() {
 			g.Specify("Cross-mounting of a blob without the from argument should yield session id", func() {
 				SkipIfDisabled(push)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
-					reggie.WithName(crossmountNamespace)).
-					SetQueryParam("mount", dummyDigest)
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
-				Expect(resp.GetAbsoluteLocation()).To(Not(BeEmpty()))
+				blobRefs, _ = mountBlob(dummyDigest, "", blobRefs, g.GinkgoT())
 			})
 
 			g.Specify("POST request to mount another repository's blob should return 201 or 202", func() {
 				SkipIfDisabled(push)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
-					reggie.WithName(crossmountNamespace)).
-					SetQueryParam("mount", testBlobADigest).
-					SetQueryParam("from", client.Config.DefaultName)
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAny(
-					Equal(http.StatusCreated),
-					Equal(http.StatusAccepted),
-				))
+				var resp *reggie.Response
+				blobRefs, resp = mountBlob(testBlobADigest, client.Config.DefaultName, blobRefs, g.GinkgoT())
 				lastResponse = resp
 			})
 
@@ -318,12 +310,7 @@ var test02Push = func() {
 				RunOnlyIf(runAutomaticCrossmountTest)
 				RunOnlyIf(lastResponse.StatusCode() == http.StatusCreated)
 				RunOnlyIf(automaticCrossmountEnabled)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
-					reggie.WithName(crossmountNamespace)).
-					SetQueryParam("mount", testBlobADigest)
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				blobRefs, _ = mountBlob(testBlobADigest, "", blobRefs, g.GinkgoT())
 			})
 
 			g.Specify("Cross-mounting without from, and automatic content discovery disabled should return a 202", func() {
@@ -331,12 +318,7 @@ var test02Push = func() {
 				RunOnlyIf(runAutomaticCrossmountTest)
 				RunOnlyIf(lastResponse.StatusCode() == http.StatusCreated)
 				RunOnlyIfNot(automaticCrossmountEnabled)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/",
-					reggie.WithName(crossmountNamespace)).
-					SetQueryParam("mount", testBlobADigest)
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(Equal(http.StatusAccepted))
+				blobRefs, _ = mountBlob(testBlobADigest, "", blobRefs, g.GinkgoT())
 			})
 		})
 
@@ -403,36 +385,10 @@ var test02Push = func() {
 				})
 			}
 
-			g.Specify("Delete config blob created in tests", func() {
+			g.Specify("Delete blobs created in tests", func() {
 				SkipIfDisabled(push)
 				RunOnlyIf(runPushSetup)
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configs[1].Digest))
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAny(
-					SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300),
-					),
-					Equal(http.StatusNotFound),
-					Equal(http.StatusMethodNotAllowed),
-				))
-			})
-
-			g.Specify("Delete layer blob created in setup", func() {
-				SkipIfDisabled(push)
-				RunOnlyIf(runPushSetup)
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAny(
-					SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300),
-					),
-					Equal(http.StatusNotFound),
-					Equal(http.StatusMethodNotAllowed),
-				))
+				deleteBlobs(blobRefs, g.GinkgoT())
 			})
 
 			if !deleteManifestBeforeBlobs {

--- a/conformance/03_discovery_test.go
+++ b/conformance/03_discovery_test.go
@@ -34,43 +34,34 @@ var test03ContentDiscovery = func() {
 
 		var numTags = 4
 		var tagList []string
+		var blobRefs []string
 		var manifestRefs []string
 
 		g.Context("Setup", func() {
 			g.Specify("Populate registry with test blob", func() {
 				SkipIfDisabled(contentDiscovery)
 				RunOnlyIf(runContentDiscoverySetup)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", configs[2].Digest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", configs[2].ContentLength).
-					SetBody(configs[2].Content)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  configs[2].Digest,
+						Content: configs[2].Content,
+						Length:  configs[2].ContentLength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 			})
 
 			g.Specify("Populate registry with test layer", func() {
 				SkipIfDisabled(contentDiscovery)
 				RunOnlyIf(runContentDiscoverySetup)
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", layerBlobDigest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", layerBlobContentLength).
-					SetBody(layerBlobData)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  layerBlobDigest,
+						Content: layerBlobData,
+						Length:  layerBlobContentLength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 			})
 
 			g.Specify("Populate registry with test tags", func() {
@@ -108,34 +99,24 @@ var test03ContentDiscovery = func() {
 				// Populate registry with empty JSON blob
 				// validate expected empty JSON blob digest
 				Expect(emptyJSONDescriptor.Digest).To(Equal(godigest.Digest("sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a")))
-				req := client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", emptyJSONDescriptor.Digest.String()).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", fmt.Sprintf("%d", emptyJSONDescriptor.Size)).
-					SetBody(emptyJSONBlob)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  emptyJSONDescriptor.Digest.String(),
+						Content: emptyJSONBlob,
+						Length:  fmt.Sprintf("%d", emptyJSONDescriptor.Size),
+					},
+					blobRefs, g.GinkgoT(),
+				)
 
 				// Populate registry with reference blob before the image manifest is pushed
-				req = client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", testRefBlobADigest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", testRefBlobALength).
-					SetBody(testRefBlobA)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  testRefBlobADigest,
+						Content: testRefBlobA,
+						Length:  testRefBlobALength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 
 				// Populate registry with test references manifest (config.MediaType = artifactType)
 				manifestRefs = pushManifest(
@@ -169,34 +150,24 @@ var test03ContentDiscovery = func() {
 				)
 
 				// Populate registry with test blob
-				req = client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", configs[4].Digest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", configs[4].ContentLength).
-					SetBody(configs[4].Content)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  configs[4].Digest,
+						Content: configs[4].Content,
+						Length:  configs[4].ContentLength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 
 				// Populate registry with test layer
-				req = client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", layerBlobDigest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", layerBlobContentLength).
-					SetBody(layerBlobData)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  layerBlobDigest,
+						Content: layerBlobData,
+						Length:  layerBlobContentLength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 
 				// Populate registry with test manifest
 				tag := testTagName
@@ -210,19 +181,14 @@ var test03ContentDiscovery = func() {
 				)
 
 				// Populate registry with reference blob after the image manifest is pushed
-				req = client.NewRequest(reggie.POST, "/v2/<name>/blobs/uploads/")
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				req = client.NewRequest(reggie.PUT, resp.GetRelativeLocation()).
-					SetQueryParam("digest", testRefBlobBDigest).
-					SetHeader("Content-Type", "application/octet-stream").
-					SetHeader("Content-Length", testRefBlobBLength).
-					SetBody(testRefBlobB)
-				resp, err = client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAll(
-					BeNumerically(">=", 200),
-					BeNumerically("<", 300)))
+				blobRefs = pushBlob(
+					&BlobInfo{
+						Digest:  testRefBlobBDigest,
+						Content: testRefBlobB,
+						Length:  testRefBlobBLength,
+					},
+					blobRefs, g.GinkgoT(),
+				)
 
 				// Populate registry with test references manifest (config.MediaType = artifactType)
 				manifestRefs = pushManifest(
@@ -404,36 +370,10 @@ var test03ContentDiscovery = func() {
 				})
 			}
 
-			g.Specify("Delete config blob created in tests", func() {
+			g.Specify("Delete blobs created in tests", func() {
 				SkipIfDisabled(contentDiscovery)
 				RunOnlyIf(runContentDiscoverySetup)
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configs[2].Digest))
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAny(
-					SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300),
-					),
-					Equal(http.StatusNotFound),
-					Equal(http.StatusMethodNotAllowed),
-				))
-			})
-
-			g.Specify("Delete layer blob created in setup", func() {
-				SkipIfDisabled(contentDiscovery)
-				RunOnlyIf(runContentDiscoverySetup)
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(layerBlobDigest))
-				resp, err := client.Do(req)
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode()).To(SatisfyAny(
-					SatisfyAll(
-						BeNumerically(">=", 200),
-						BeNumerically("<", 300),
-					),
-					Equal(http.StatusNotFound),
-					Equal(http.StatusMethodNotAllowed),
-				))
+				deleteBlobs(blobRefs, g.GinkgoT())
 			})
 
 			if !deleteManifestBeforeBlobs {
@@ -443,38 +383,6 @@ var test03ContentDiscovery = func() {
 					deleteManifests(manifestRefs, g.GinkgoT())
 				})
 			}
-
-			g.Specify("References teardown", func() {
-				SkipIfDisabled(contentDiscovery)
-				RunOnlyIf(runContentDiscoverySetup)
-
-				deleteReq := func(req *reggie.Request) {
-					resp, err := client.Do(req)
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode()).To(SatisfyAny(
-						SatisfyAll(
-							BeNumerically(">=", 200),
-							BeNumerically("<", 300),
-						),
-						Equal(http.StatusNotFound),
-						Equal(http.StatusMethodNotAllowed),
-					))
-				}
-
-				// Delete config blob created in setup
-				req := client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(configs[4].Digest))
-				deleteReq(req)
-
-				// Delete reference blob created in setup
-				req = client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(testRefBlobADigest))
-				deleteReq(req)
-				req = client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(testRefBlobBDigest))
-				deleteReq(req)
-
-				// Delete empty JSON blob created in setup
-				req = client.NewRequest(reggie.DELETE, "/v2/<name>/blobs/<digest>", reggie.WithDigest(emptyJSONDescriptor.Digest.String()))
-				deleteReq(req)
-			})
 		})
 	})
 }

--- a/conformance/setup.go
+++ b/conformance/setup.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"math/big"
 	mathrand "math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	g "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/formatter"
+	. "github.com/onsi/gomega"
 	godigest "github.com/opencontainers/go-digest"
 )
 
@@ -674,4 +676,92 @@ func setupChunkedBlob(size int) {
 	testBlobBChunk2 = testBlobB[size/2+1:]
 	testBlobBChunk2Length = strconv.Itoa(len(testBlobBChunk2))
 	testBlobBChunk2Range = fmt.Sprintf("%d-%d", len(testBlobBChunk1), len(testBlobB)-1)
+}
+
+type ManifestInfo struct {
+	Index   bool
+	Tag     string
+	Digest  string
+	Content []byte
+	Subject string
+}
+
+func pushManifest(
+	manifestInfo *ManifestInfo,
+	manifestRefs []string,
+	t g.GinkgoTInterface,
+) []string {
+	t.Helper()
+	// if tag passed, use it as reference, otherwise use digest
+	reference := manifestInfo.Tag
+	if reference == "" {
+		reference = manifestInfo.Digest
+	}
+	// if index, use corresponding mediaType
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+	if manifestInfo.Index {
+		mediaType = "application/vnd.oci.image.index.v1+json"
+	}
+	// push manifest
+	req := client.NewRequest(reggie.PUT, "/v2/<name>/manifests/<reference>",
+		reggie.WithReference(reference)).
+		SetHeader("Content-Type", mediaType).
+		SetBody(manifestInfo.Content)
+	resp, err := client.Do(req)
+	// check all expectations
+	Expect(err).To(BeNil())
+	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+	Expect(resp.Header().Get("Location")).ToNot(BeEmpty())
+	// OCI-Subject is empty if referrers API unsupported
+	Expect(resp.Header().Get("OCI-Subject")).To(SatisfyAny(
+		Equal(manifestInfo.Subject),
+		Equal("")))
+	// keep track of all reference(s) to manifest
+	manifestRefs = append(manifestRefs, reference)
+	if manifestInfo.Tag != "" {
+		manifestRefs = append(manifestRefs, manifestInfo.Digest)
+	}
+	return manifestRefs
+}
+
+func deleteManifest(
+	ref string,
+	t g.GinkgoTInterface,
+) {
+	t.Helper()
+
+	req := client.NewRequest(reggie.GET, "/v2/<name>/manifests/<reference>",
+		reggie.WithReference(ref))
+	resp, err := client.Do(req)
+	Expect(err).To(BeNil())
+	if resp.StatusCode() == http.StatusOK {
+		req := client.NewRequest(reggie.DELETE, "/v2/<name>/manifests/<reference>",
+			reggie.WithReference(ref))
+		resp, err := client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(resp.StatusCode()).To(SatisfyAny(
+			Equal(http.StatusAccepted),
+			Equal(http.StatusMethodNotAllowed),
+			Equal(http.StatusNotFound),
+		))
+		req = client.NewRequest(reggie.GET, "/v2/<name>/manifests/<ref>",
+			reggie.WithReference(ref))
+		resp, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(resp.StatusCode()).To(Equal(http.StatusNotFound))
+	}
+}
+
+func deleteManifests(
+	manifestRefs []string,
+	t g.GinkgoTInterface,
+) {
+	t.Helper()
+
+	for len(manifestRefs) > 0 {
+		index := len(manifestRefs) - 1
+		ref := manifestRefs[index]
+		manifestRefs = manifestRefs[:index]
+		deleteManifest(ref, t)
+	}
 }


### PR DESCRIPTION
Running the tests against a local ZOT registry it is possible to observe that the tests don't delete properly all pushed manifests and blobs. This PR introduces a list to keep track of pushed manifests and blobs to properly clean them up on test termination.

Additionally reducing code duplication through the introduction of functions for pushing and deleting manifests and blobs.