### PR TITLE
Update extensions spec

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -24,9 +24,12 @@ _notice_: All new `/extensions/_<extention>.md` docs MUST be added to this table
 Extension names MUST be unique.
 Extensions recorded in this distribution-spec are considered canonical definitions.
 
-Extensions are specified by extension name (`<extension>`) aligning with the project, followed by the `<component>`, and last by by the `<module>`.
-This constitutes the URI segments of the extension endpoint.
+Extensions are specified by an underscore followed by the extension name (`_<extension>`) aligning with the project.
+The rest of the URI segments are defined by the extension.
+They MUST be defined in a way that prevents clashes between routes on the same extension.
 Additional options may be passed as parameters to the endpoint.
+
+The following is an example of a potential extension:
 
 ```http
 _<extension>/<component>/<module>[?<key>=<value>&...]


### PR DESCRIPTION
Update extensions spec to use relaxed language around route definition. The current language requires an extension to use <component> and <module> segments, and pass required dynamic values via query parameter.

This change loosens the requirements and leaves API design up to the extension itself, with the only requirement being that the routes do not clash.

Prior implementation: https://edu.chainguard.dev/chainguard/chainguard-images/features/using-the-tag-history-api/#calling-the-api