### PR TITLE
Fix: Upload artifacts in conformance test

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       run: |
         set -x
         set +e
-        OCI_RESULTS_DIR=${OCI_RESULTS_DIR:-.}
+        export OCI_RESULTS_DIR=${OCI_RESULTS_DIR:-.}
         conformance
         conformance_rc="$?"
         set -e


### PR DESCRIPTION
This fixes the generation of artifacts in the conformance results. When the variable isn't exported, the default "results" directory is used for outputting the results.