### PR TITLE
Add `DisableCompression: true` to our conformance `Transport`

### DIFF
--- a/conformance/run.go
+++ b/conformance/run.go
@@ -65,9 +65,20 @@ func runnerNew(c config) (*runner, error) {
 	if c.LoginUser != "" && c.LoginPass != "" {
 		apiOpts = append(apiOpts, apiWithAuth(c.LoginUser, c.LoginPass, c.CacheAuth))
 	}
+
+	// TODO <tianon> ideally we wouldn't just blatantly DisableCompression here, but we currently (2026-08-27) have a bunch of tests that assume Content-Length is set that Go's transparent handling of transport compression makes fail if a server happens to implement transport compression
+	client := &http.Client{}
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport := t.Clone()
+		transport.DisableCompression = true
+		client.Transport = transport
+	} else {
+		return nil, fmt.Errorf("changing the DefaultTransport is not supported")
+	}
+
 	r := runner{
 		Config:  c,
-		API:     apiNew(http.DefaultClient, apiOpts...),
+		API:     apiNew(client, apiOpts...),
 		State:   stateNew(),
 		Results: resultsNew(testName, nil),
 		Log:     slog.New(slog.NewTextHandler(c.LogWriter, &slog.HandlerOptions{Level: lvl})),


### PR DESCRIPTION
Technically, the spec *does* support transport compression by never making `Content-Length` a `MUST` on a `GET`, but the conformance tests currently don't agree with that, so running them against a server that *does* implement transport compression has Go's `net/http` by-default requesting transport compression and transparently stripping it on response bodies, but then having to strip `ContentLength` (because it's over the compressed data).

As a result, over 200 tests fail on such a server. 😂

On the flip side, we haven't really seen this much in practice because Go's *server* does not implement transparent transport compression like the client does, so this only shows up if a server explicitly implements it.

This is intended to be a temporary band-aid, by disabling Go's transparent transport compression handling, which fixes the test failures on a server which actually implements transport compression.

- see also https://github.com/cue-labs/oci/issues/38 (where I've bumped into this problem before)