### PR TITLE
Add `digest-algorithm` tests in conformance

### DIFF
--- a/conformance/api.go
+++ b/conformance/api.go
@@ -290,7 +290,6 @@ func (a *api) BlobMount(registry, repo, source string, dig digest.Digest, td *te
 		qa.Set("from", source)
 	}
 	u.RawQuery = qa.Encode()
-	// TODO: add digest algorithm if not sha256
 	errs := []error{}
 	loc := ""
 	status := 0
@@ -356,7 +355,11 @@ func (a *api) BlobPatchChunked(registry, repo string, dig digest.Digest, td *tes
 	if err != nil {
 		return err
 	}
-	// TODO: add digest algorithm if not sha256
+	if flags["DigestAlgorithmParam"] {
+		qa := u.Query()
+		qa.Set("digest-algorithm", dig.Algorithm().String())
+		u.RawQuery = qa.Encode()
+	}
 	minStr := ""
 	loc := ""
 	resp := http.Response{Header: http.Header{}}
@@ -555,7 +558,11 @@ func (a *api) BlobPatchStream(registry, repo string, dig digest.Digest, td *test
 	if err != nil {
 		return err
 	}
-	// TODO: add digest algorithm if not sha256
+	if flags["DigestAlgorithmParam"] {
+		qa := u.Query()
+		qa.Set("digest-algorithm", dig.Algorithm().String())
+		u.RawQuery = qa.Encode()
+	}
 	loc := ""
 	resp := http.Response{Header: http.Header{}}
 	err = a.Do(
@@ -767,7 +774,11 @@ func (a *api) BlobPostPut(registry, repo string, dig digest.Digest, td *testData
 	if err != nil {
 		return err
 	}
-	// TODO: add digest algorithm if not sha256
+	if flags["DigestAlgorithmParam"] {
+		qa := u.Query()
+		qa.Set("digest-algorithm", dig.Algorithm().String())
+		u.RawQuery = qa.Encode()
+	}
 	loc := ""
 	resp := http.Response{Header: http.Header{}}
 	err = a.Do(

--- a/conformance/run.go
+++ b/conformance/run.go
@@ -914,6 +914,11 @@ func (r *runner) TestBlobAPIs(parent *results, tdName, tdDesc string, algo diges
 			blobAPIsTestedByAlgo[algo] = &[stateAPIMax]bool{}
 		}
 		blobAPITests := []string{"post only", "post+put", "chunked single", "stream", "mount", "mount anonymous", "mount missing", "post cancel"}
+		if algo != digest.Canonical {
+			// the initial POST for these APIs precedes the client sending the digest, so also
+			// verify the registry accepts the digest-algorithm hint for non-canonical algorithms
+			blobAPITests = append(blobAPITests, "post+put with digest-algorithm", "chunked with digest-algorithm", "stream with digest-algorithm")
+		}
 		for _, name := range blobAPITests {
 			dig, _, err := r.State.Data[tdName].genBlob(genWithBlobSize(512), genWithAlgo(algo))
 			if err != nil {
@@ -1024,6 +1029,24 @@ func (r *runner) TestBlobAPIs(parent *results, tdName, tdDesc string, algo diges
 				case "stream":
 					api = stateAPIBlobPatchStream
 					err = r.TestPushBlobPatchStream(res, tdName, repo, dig)
+					if err != nil {
+						errs = append(errs, err)
+					}
+				case "post+put with digest-algorithm":
+					api = stateAPIBlobPostPut
+					err = r.TestPushBlobPostPut(res, tdName, repo, dig, apiWithFlag("DigestAlgorithmParam"))
+					if err != nil {
+						errs = append(errs, err)
+					}
+				case "chunked with digest-algorithm":
+					api = stateAPIBlobPatchChunked
+					err = r.TestPushBlobPatchChunked(res, tdName, repo, dig, apiWithFlag("DigestAlgorithmParam"))
+					if err != nil {
+						errs = append(errs, err)
+					}
+				case "stream with digest-algorithm":
+					api = stateAPIBlobPatchStream
+					err = r.TestPushBlobPatchStream(res, tdName, repo, dig, apiWithFlag("DigestAlgorithmParam"))
 					if err != nil {
 						errs = append(errs, err)
 					}


### PR DESCRIPTION
This was added as an optional query parameter in eadf94bb67ef5aafae6803c95d3116b5466c6a34 (https://github.com/opencontainers/distribution-spec/pull/543) but not the conformance tests.

Assisted-By: "claude my eyes right out"